### PR TITLE
Packaging and initial readme

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,77 @@
+name: Publish PelicanFS distribution to PyPI
+on: 
+  release:
+    types:
+      - published
+
+jobs:
+  publish-to-pypi:
+    if: "!github.event.release.prerelease"
+    name: >-
+      Publish Python Distribution to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pelicanfs
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/downaload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+always_job: 
+  name: Always run job 
+  runs-on: ubuntu-latest
+  steps:
+    - name: Always run
+      run: echo "This job is used to prevent the workflow status from showing as failed when all other jobs are skipped."

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,0 +1,91 @@
+name: Publish PelicanFS distribution to TestPyPI
+on: pre-release
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python 3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artiface@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-test-pypi:
+    name: >-
+      Publish Python Distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pelicanfs
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/downaload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        respository-url: https://test.pypi.org/legacy
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-test-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,5 +1,8 @@
 name: Publish PelicanFS distribution to TestPyPI
-on: pre-release
+on: 
+  release:
+    types:
+      - prereleased
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# pelicanfs
-An ffspec implementation that uses the pelican client
+# PelicanFS
+
+## Overview
+
+PelicanFS is a file system interface (fsspec) for the Pelican Platform.  For more information about the Pelican Platform, please visit the [Pelican Platform](https://pelicanplatform.org) and the [Pelican Platform Github](https://github.com/PelicanPlatform/pelican) pages. For more information about fsspec, visit the [filesystem-spec](https://filesystem-spec.readthedocs.io/en/latest/index.html) page.
+
+
+## Limitations
+
+PelicanFS is built on top of the http fsspec implementation. As such, any functionality that isn’t available in the http implementation is also *not* available in PelicanFS.
+
+### Installation
+
+To install pelican, run:```pip install pelicanfs```### Using PelicanFS
+
+To use pelicanfs, first create a `PelicanFileSystem` and provide it with the url for the director of your data federation. As an example using the OSDF director
+
+```python
+from pelicanfs.core import PelicanFileSystem
+
+pelfs = PelicanFileSystem("https://osdf-director.osg-htc.org/")
+```
+
+From there, use `pelfs` as you would an http fsspec using a namespace path as the url path. For example:
+
+```python
+hello_world = pelfs.cat('/ospool/uc-shared/public/OSG-Staff/validation/test.txt')
+print(hello_world)
+```
+
+### Getting an FSMap
+
+Sometimes various systems that interact with an fsspec want a key-value mapper rather than a url. To do that, call the `PelicanMap` function with the namespace path and a `PelicanFileSystem` object rather than using the fsspec `get_mapper` call. For example
+
+```python
+from pelicanfs.core import PelicanFileSystem, PelicanMap
+
+pelfs = PelicanFileSystem(“some-director-url”)
+file1 = PelicanMap(“namespace/file/1”, pelfs=pelfs)
+file2 = PelicanMap(“namespace/file/2”, pelfs=pelfs)
+ds = xarray.open_mfdataset([file1,file2], engine='zarr')
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PelicanFS is a file system interface (fsspec) for the Pelican Platform.  For more information about the Pelican Platform, please visit the [Pelican Platform](https://pelicanplatform.org) and the [Pelican Platform Github](https://github.com/PelicanPlatform/pelican) pages. For more information about fsspec, visit the [filesystem-spec](https://filesystem-spec.readthedocs.io/en/latest/index.html) page.
+PelicanFS is a file system interface (fsspec) for the Pelican Platform.  For more information about pelican, see our [main website](https://pelicanplatform.org) or [Github page](https://github.com/PelicanPlatform/pelican). For more information about fsspec, visit the [filesystem-spec](https://filesystem-spec.readthedocs.io/en/latest/index.html) page.
 
 
 ## Limitations
@@ -21,7 +21,7 @@ from pelicanfs.core import PelicanFileSystem
 pelfs = PelicanFileSystem("https://osdf-director.osg-htc.org/")
 ```
 
-From there, use `pelfs` as you would an http fsspec using a namespace path as the url path. For example:
+Once `pelfs` is pointed at your federation's director, fsspec commands can be applied to Pelican namespaces. For example:
 
 ```python
 hello_world = pelfs.cat('/ospool/uc-shared/public/OSG-Staff/validation/test.txt')
@@ -36,7 +36,7 @@ Sometimes various systems that interact with an fsspec want a key-value mapper r
 from pelicanfs.core import PelicanFileSystem, PelicanMap
 
 pelfs = PelicanFileSystem(“some-director-url”)
-file1 = PelicanMap(“namespace/file/1”, pelfs=pelfs)
-file2 = PelicanMap(“namespace/file/2”, pelfs=pelfs)
+file1 = PelicanMap(“/namespace/file/1”, pelfs=pelfs)
+file2 = PelicanMap(“/namespace/file/2”, pelfs=pelfs)
 ds = xarray.open_mfdataset([file1,file2], engine='zarr')
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ PelicanFS is built on top of the http fsspec implementation. As such, any functi
 
 ### Installation
 
-To install pelican, run:```pip install pelicanfs```### Using PelicanFS
+To install pelican, run:
+
+```
+pip install pelicanfs
+```
+
+To install from source, run:
+
+```
+git clone https://github.com/PelicanPlatform/pelicanfs.git
+cd pelicanfs
+pip install -e .
+```
+
+
+### Using PelicanFS
 
 To use pelicanfs, first create a `PelicanFileSystem` and provide it with the url for the director of your data federation. As an example using the OSDF director
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+license_files = LICENSE
+
+[options]
+packages = find:
+package_dir =
+    =src
+
+[options.packages.find]
+where = src
+include = pelicanfs*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,43 @@
+from setuptools import setup, find_packages
+
+packages = find_packages()
+print(packages)
+
+setup(
+    name="pelicanfs",
+    version="0.0.1",
+    description="An FSSpec Implementation using the Pelican System",
+    url = "https://github.com/PelicanPlatform/pelicanfs",
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Science/Research",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3 :: Only",
+        "License :: OSI Approved :: Apache Software License",
+    ],
+    keywords="pelican, fsspec",
+        packages=find_packages(
+        where='src',
+        include=['pelicanfs*'],
+    ),
+    package_dir={"": "src"},
+    python_requires=">=3.7, <4",
+    install_requires=["aiohttp==3.9.4", 
+                      "aiosignal==1.3.1",
+                      "async-timeout==4.0.3",
+                      "attrs==23.2.0",
+                      "frozenlist==1.4.1",
+                      "fsspec==2024.3.1",
+                      "idna==3.7",
+                      "multidict==6.0.5",
+                      "yarl==1.9.4"],
+    project_urls={
+        "Source": "https://github.com/PelicanPlatform/pelicanfs",
+        "Pelican Source": "https://github.com/PelicanPlatform/pelican",
+        "Bug Reports":"https://github.com/PelicanPlatform/pelicanfs/issues"
+    },
+)

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -17,7 +17,7 @@ limitations under the License.
 import fsspec
 import fsspec.registry
 from fsspec.asyn import AsyncFileSystem
-import pelicanfs.dir_header_parser as dir_header_parser
+from .dir_header_parser import parse_metalink, get_dirlist_loc
 import fsspec.implementations.http as fshttp
 import aiohttp
 import urllib.parse
@@ -91,7 +91,7 @@ class PelicanFileSystem(AsyncFileSystem):
         Returns the highest priority cache for the namespace that appears to be owrking
         """
         headers = await self.get_director_headers(fileloc)
-        metalist = dir_header_parser.parse_metalink(headers)[1:]
+        metalist = parse_metalink(headers)[1:]
         while len(metalist) > 0:
             updatedUrl = metalist[0][0]
             metalist = metalist[1:]
@@ -122,7 +122,7 @@ class PelicanFileSystem(AsyncFileSystem):
             path = args[0]
             parsedUrl = urllib.parse.urlparse(path)
             headers = await self.get_director_headers(parsedUrl.path)
-            dirlistloc = dir_header_parser.get_dirlist_loc(headers)
+            dirlistloc = get_dirlist_loc(headers)
             if dirlistloc == None:
                 raise RuntimeError
             listUrl = dirlistloc + "/" + parsedUrl.path
@@ -146,7 +146,7 @@ class PelicanFileSystem(AsyncFileSystem):
     async def _walk(self, path, maxdepth=None, on_error="omit", **kwargs):
         parsedUrl = urllib.parse.urlparse(path)
         headers = await self.get_director_headers(parsedUrl.path)
-        dirlistloc = dir_header_parser.get_dirlist_loc(headers)
+        dirlistloc = get_dirlist_loc(headers)
         if dirlistloc == "":
             raise RuntimeError
         listUrl = dirlistloc + "/" + path


### PR DESCRIPTION
A slightly better readme documentation.

Adds workflows for the both the pypi and test-pypi packaging. The logic being that eventually, on "release" we'll want to publish the package to pypi.org but on a "pre-release" we want to publish to test-pypi.

Owners and maintainers in for the pelicanfs can also still publish distributions from outside of github if needed. There is currently a pelicanfs package on pypi with this version of the source code now, but the workflows are preparing for the future.