### PR TITLE
Expand endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ pip install -e .
 
 ### Using PelicanFS
 
-To use pelicanfs, first create a `PelicanFileSystem` and provide it with the url for the director of your data federation. As an example using the OSDF director
+To use pelicanfs, first create a `PelicanFileSystem` and provide it with the pelican federation url. As an example using the OSDF federation
 
 ```python
 from pelicanfs.core import PelicanFileSystem
 
-pelfs = PelicanFileSystem("https://osdf-director.osg-htc.org/")
+pelfs = PelicanFileSystem("pelican://osg-htc.org")
 ```
 
 Once `pelfs` is pointed at your federation's director, fsspec commands can be applied to Pelican namespaces. For example:
@@ -45,7 +45,7 @@ print(hello_world)
 
 ### Getting an FSMap
 
-Sometimes various systems that interact with an fsspec want a key-value mapper rather than a url. To do that, call the `PelicanMap` function with the namespace path and a `PelicanFileSystem` object rather than using the fsspec `get_mapper` call. For example
+Sometimes various systems that interact with an fsspec want a key-value mapper rather than a url. To do that, call the `PelicanMap` function with the namespace path and a `PelicanFileSystem` object rather than using the fsspec `get_mapper` call. For example:
 
 ```python
 from pelicanfs.core import PelicanFileSystem, PelicanMap
@@ -54,4 +54,47 @@ pelfs = PelicanFileSystem(“some-director-url”)
 file1 = PelicanMap(“/namespace/file/1”, pelfs=pelfs)
 file2 = PelicanMap(“/namespace/file/2”, pelfs=pelfs)
 ds = xarray.open_mfdataset([file1,file2], engine='zarr')
+```
+
+### Specifying Endpoints
+
+The following describes how to specify endpoints to get data from, rather than letting PelicanFS and the director determine the best cache. PelicanFS allows you to specify whether to read directly from the origin (bypassing data staging altogether) or to name a specific cache to stage data into. 
+
+**Note**
+If both direct reads and a specific cache are set, PelicanFS will use the specified cache and ignore the direct reads setting.
+
+
+### Enabling Direct Reads
+
+Sometimes you might wish to read data directly from an origin rather than via a cache. To enable this at PelicanFileSystem creation, just pass in `dirReads=True` to the constructor.
+
+```python
+pelfs = PelicanFileSystem("some-federation-url", dirReads=True)
+```
+
+Direct reads can also be turned on an off using the class function `set_direct_reads` like so:
+
+```python
+pelfs.set_direct_reads(True)
+hello_world_from_origin = pelfs.cat('/ospool/uc-shared/public/OSG-Staff/validation/test.txt')
+```
+
+### Specifying a Cache
+
+If you want to specify a specific cache to stage your data into (as opposed to the highest priority working cache), this can be done by passing in a cache URL during PelicanFileSystem construction via the `specifiedCacheUrl` variable:
+
+```python
+pelfs = PelicanFileSystem("some-federation-url", specifiedCacheUrl="some-cace-url")
+```
+
+Or by setting it via the `set_cache` function like so:
+
+```python
+pelfs.set_cache("some-cache-curl")
+```
+
+You can clear the specifed cache by calling the `reset_cache` function:
+
+```python
+pelfs.reset_cache()
 ```

--- a/README.md
+++ b/README.md
@@ -66,35 +66,26 @@ The following describes how to specify endpoints to get data from, rather than l
 
 #### Enabling Direct Reads
 
-Sometimes you might wish to read data directly from an origin rather than via a cache. To enable this at PelicanFileSystem creation, just pass in `dirReads=True` to the constructor.
+Sometimes you might wish to read data directly from an origin rather than via a cache. To enable this at PelicanFileSystem creation, just pass in `direct_reads=True` to the constructor.
 
 ```python
-pelfs = PelicanFileSystem("some-federation-url", dirReads=True)
-```
-
-Direct reads can also be turned on an off using the class function `set_direct_reads` like so:
-
-```python
-pelfs.set_direct_reads(True)
-hello_world_from_origin = pelfs.cat('/ospool/uc-shared/public/OSG-Staff/validation/test.txt')
+pelfs = PelicanFileSystem("pelican://osg-htc.org", direct_reads=True)
 ```
 
 #### Specifying a Cache
 
-If you want to specify a specific cache to stage your data into (as opposed to the highest priority working cache), this can be done by passing in a cache URL during PelicanFileSystem construction via the `specifiedCacheUrl` variable:
+If you want to specify a specific cache to stage your data into (as opposed to the highest priority working cache), this can be done by passing in a cache URL during PelicanFileSystem construction via the `preferred_caches` variable:
 
 ```python
-pelfs = PelicanFileSystem("some-federation-url", specifiedCacheUrl="some-cache-url")
+pelfs = PelicanFileSystem("pelican://osg-htc.org", preferred_caches=["https://cache.example.com"])
 ```
 
-Or by setting it via the `set_cache` function like so:
+or
 
 ```python
-pelfs.set_cache("some-cache-url")
+pelfs = PelicanFileSystem("pelican://osg-htc.org", preferred_caches=["https://cache.example.com",
+    "https://cache2.example.com", "+"])
 ```
 
-You can clear the specifed cache by calling the `reset_cache` function:
-
-```python
-pelfs.reset_cache()
-```
+Note that the special cache value `"+"` indicates that the provided preferred caches should be prepended to the
+list of caches from the director.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ ds = xarray.open_mfdataset([file1,file2], engine='zarr')
 The following describes how to specify endpoints to get data from, rather than letting PelicanFS and the director determine the best cache. PelicanFS allows you to specify whether to read directly from the origin (bypassing data staging altogether) or to name a specific cache to stage data into. 
 
 **Note**
-If both direct reads and a specific cache are set, PelicanFS will use the specified cache and ignore the direct reads setting.
+> If both direct reads and a specific cache are set, PelicanFS will use the specified cache and ignore the direct reads setting.
 
 
-### Enabling Direct Reads
+#### Enabling Direct Reads
 
 Sometimes you might wish to read data directly from an origin rather than via a cache. To enable this at PelicanFileSystem creation, just pass in `dirReads=True` to the constructor.
 
@@ -79,18 +79,18 @@ pelfs.set_direct_reads(True)
 hello_world_from_origin = pelfs.cat('/ospool/uc-shared/public/OSG-Staff/validation/test.txt')
 ```
 
-### Specifying a Cache
+#### Specifying a Cache
 
 If you want to specify a specific cache to stage your data into (as opposed to the highest priority working cache), this can be done by passing in a cache URL during PelicanFileSystem construction via the `specifiedCacheUrl` variable:
 
 ```python
-pelfs = PelicanFileSystem("some-federation-url", specifiedCacheUrl="some-cace-url")
+pelfs = PelicanFileSystem("some-federation-url", specifiedCacheUrl="some-cache-url")
 ```
 
 Or by setting it via the `set_cache` function like so:
 
 ```python
-pelfs.set_cache("some-cache-curl")
+pelfs.set_cache("some-cache-url")
 ```
 
 You can clear the specifed cache by calling the `reset_cache` function:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
                       "yarl==1.9.4",
                       "cachetools~=5.3"],
     extras_require={
-                    "testing": ["pytest", "pytest-httpserver"],
+                    "testing": ["pytest", "pytest-httpserver", "trustme"],
                    },
     project_urls={
         "Source": "https://github.com/PelicanPlatform/pelicanfs",

--- a/test/test_osdf.py
+++ b/test/test_osdf.py
@@ -15,8 +15,14 @@ limitations under the License.
 """
 
 import fsspec
+import pelicanfs.core
 
 def test_osdf():
     with fsspec.open("osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt") as of:
         data = of.read()
+    assert data == b'Hello, World!\n'
+
+def test_osdf_direct():
+    pelfs = pelicanfs.core.PelicanFileSystem("pelican://osg-htc.org", direct_reads=True)
+    data = pelfs.cat("/ospool/uc-shared/public/OSG-Staff/validation/test.txt")
     assert data == b'Hello, World!\n'


### PR DESCRIPTION
This closes three issues:

1. Closes #14 : The "pelican://federation-disc-url" to discover the federation metadata and the director endpoint.
2. Closes #33 : Adds a direct-reads functionality to the code
3. Closes #34 : Allows the user to specify a cache to be used