### PR TITLE
Cache information about the namespace

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -1,0 +1,24 @@
+name: Python testing
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install Dependencies
+      run: |
+        python3 -m pip install '.[testing]'
+    - name: Test with pytest
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+src/pelicanfs.egg-info/
+src/pelicanfs/__pycache__/
+test/__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
                       "fsspec==2024.3.1",
                       "idna==3.7",
                       "multidict==6.0.5",
-                      "yarl==1.9.4"],
+                      "yarl==1.9.4",
+                      "cachetools~=5.3"],
     project_urls={
         "Source": "https://github.com/PelicanPlatform/pelicanfs",
         "Pelican Source": "https://github.com/PelicanPlatform/pelican",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,12 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: Apache Software License",
     ],
+    entry_points={
+        'fsspec.specs': [
+            'pelican=pelicanfs.core.PelicanFileSystem',
+            'osdf=pelicanfs.core.OSDFFileSystem'
+        ],
+    },
     keywords="pelican, fsspec",
         packages=find_packages(
         where='src',

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(
                       "multidict==6.0.5",
                       "yarl==1.9.4",
                       "cachetools~=5.3"],
+    extras_require={
+                    "testing": ["pytest", "pytest-httpserver"],
+                   },
     project_urls={
         "Source": "https://github.com/PelicanPlatform/pelicanfs",
         "Pelican Source": "https://github.com/PelicanPlatform/pelican",

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -14,14 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License. 
 """
 
+import cachetools
 import fsspec
 import fsspec.registry
-from fsspec.asyn import AsyncFileSystem
+from fsspec.asyn import AsyncFileSystem, sync
 from .dir_header_parser import parse_metalink, get_dirlist_loc
 import fsspec.implementations.http as fshttp
 import aiohttp
 import urllib.parse
 import asyncio
+import threading
+import logging
+
+logger = logging.getLogger("fsspec.pelican")
+
+class PelicanException(RuntimeError):
+    """
+    Base class for all Pelican-related failures
+    """
+    pass
+
+class NoAvailableSource(PelicanException):
+    """
+    No source endpoint is currently available for the requested object
+    """
+    pass
 
 class PelicanFileSystem(AsyncFileSystem):
     """
@@ -47,7 +64,9 @@ class PelicanFileSystem(AsyncFileSystem):
             asynchronous = False,
             loop = None
     ):
-        
+        self._namespace_cache = cachetools.TTLCache(maxsize=50, ttl=15*60)
+        self._namespace_lock = threading.Lock()
+
         # The internal filesystem
         self.httpFileSystem = fshttp.HTTPFileSystem(asynchronous=asynchronous, loop=loop)
 
@@ -90,26 +109,47 @@ class PelicanFileSystem(AsyncFileSystem):
         """
         Returns the highest priority cache for the namespace that appears to be owrking
         """
+        cacheUrl = self._match_namespace(fileloc)
+        if cacheUrl:
+            return cacheUrl
+
         headers = await self.get_director_headers(fileloc)
-        metalist = parse_metalink(headers)[1:]
-        while len(metalist) > 0:
+        metalist, namespace = parse_metalink(headers)
+        goodEntry = False
+        cache_list = []
+        while metalist:
             updatedUrl = metalist[0][0]
-            metalist = metalist[1:]
             # Timeout response in seconds - the default response is 5 minutes
-            timeout = aiohttp.ClientTimeout(total=2)
-            async with aiohttp.ClientSession() as session:
-                try:
-                    async with session.get(updatedUrl, timeout=timeout) as resp:
-                        resp.status
-                except (aiohttp.client_exceptions.ClientConnectorError, FileNotFoundError, asyncio.TimeoutError, asyncio.exceptions.TimeoutError):
-                    continue
-                break
-        if len(metalist) == 0:
+            timeout = aiohttp.ClientTimeout(total=5)
+            session = await self.httpFileSystem.set_session()
+            try:
+                async with session.head(updatedUrl, timeout=timeout) as resp:
+                    pass
+                    break
+            except (aiohttp.client_exceptions.ClientConnectorError, FileNotFoundError, asyncio.TimeoutError, asyncio.exceptions.TimeoutError):
+                pass
+            metalist = metalist[1:]
+        if not metalist:
             # No working cache was found
-            raise RuntimeError
-        
+            raise NoAvailableSource()
+        with self._namespace_lock:
+            self._namespace_cache[namespace] = _CacheManager([i[0] for i in metalist])
+
         return updatedUrl
 
+    def _match_namespace(self, fileloc):
+        namespace_info = None
+        with self._namespace_lock:
+            prefixes = list(self._namespace_cache.keys())
+            prefixes.sort(reverse=True)
+            for prefix in prefixes:
+                if fileloc.startswith(prefix):
+                    namespace_info = self._namespace_cache.get(prefix)
+                    break
+        if not namespace_info:
+            return
+
+        return namespace_info.get_url(fileloc)
     
     def _dirlist_dec(func):
         """
@@ -153,22 +193,17 @@ class PelicanFileSystem(AsyncFileSystem):
         async for _ in self.httpFileSystem._walk(listUrl, maxdepth, on_error, **kwargs):
                 yield _
 
+    def open(self, path, **kwargs):
+        cache_url = sync(self.loop, self.get_working_cache, path)
+        return self.httpFileSystem.open(cache_url, **kwargs)
 
-    def _open(
+    async def open_async(
         self,
         path,
-        mode="rb",
-        block_size=None,
-        autocommit=None,  # XXX: This differs from the base class.
-        cache_type=None,
-        cache_options=None,
-        size=None,
         **kwargs,
     ):    
-        loop = asyncio.get_event_loop()
-        cache_url = loop.run_until_complete(self.get_working_cache(path))
-
-        return self.httpFileSystem._open(cache_url, mode, block_size, autocommit, cache_type, cache_options, size, **kwargs)
+        cache_url = await self.get_working_cache(path)
+        return self.httpFileSystem.open_async(cache_url, **kwargs)
     
 
 
@@ -269,3 +304,51 @@ def PelicanMap(root, pelfs, check=False, create=False):
     cache_url = loop.run_until_complete(pelfs.get_working_cache(root))
 
     return pelfs.get_mapper(cache_url, check=check, create=create)
+
+class _CacheManager(object):
+    """
+    Manage a list of caches.
+
+    Each entry in the namespace has an associated list of caches that are willing
+    to provide services to the client.  As the caches are used, if they timeout
+    or otherwise cause errors, they should be skipped for future operations.
+    """
+
+    def __init__(self, cache_list):
+        """
+        Construct a new cache manager from an ordered list of cache URL strings.
+        The cache URL is assumed to have the form of:
+            scheme://hostname[:port]
+        e.g., https://cache.example.com:8443 or http://cache2.example.com
+
+        The list ordering is assumed to be the order of preference; the first cache
+        in the list will be used until it's explicitly noted as bad.
+        """
+        self._lock = threading.Lock()
+        self._cache_list = []
+        # Work around any bugs where the director may return the same cache twice
+        cache_set = set()
+        for cache in cache_list:
+            parsed_url = urllib.parse.urlparse(cache)
+            parsed_url = parsed_url._replace(path="", query="", fragment="")
+            cache_str = parsed_url.geturl()
+            if cache_str in cache_set:
+                continue
+            cache_set.add(cache_str)
+            self._cache_list.append(parsed_url.geturl())
+
+    def get_url(self, obj_name):
+        """
+        Given an object name, return the currently-preferred
+        """
+        with self._lock:
+            if not self._cache_list:
+                raise NoAvailableSource()
+
+            return urllib.parse.urljoin(self._cache_list[0], obj_name)
+
+    def bad_cache(self, cache_url):
+        cache_url_parsed = urllib.parse.urlparse(cache_url)
+        cache_url_parsed = cache_url_parsed._replace(path="", query="", fragment="")
+        with self._lock:
+            self._cache_list.remove(cache_url_parsed.geturl())

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -252,8 +252,17 @@ class PelicanFileSystem(AsyncFileSystem):
     async def _expand_path(self, path, recursive=False, maxdepth=None):
         return await self.httpFileSystem._expand_path(path, recursive, maxdepth)
     
+class OSDFFileSystem(PelicanFileSystem):
+    """
+    A FSSpec AsyncFileSystem representing the OSDF
+    """
 
-fsspec.register_implementation(PelicanFileSystem.protocol, PelicanFileSystem)
+    protocol = "osdf"
+
+    def __init__(self, **kwargs):
+        # TODO: Once the base class takes `pelican://` URLs, switch to
+        # `pelican://osg-htc.org`
+        super().__init__("https://osdf-director.osg-htc.org", **kwargs)
 
 def PelicanMap(root, pelfs, check=False, create=False):
     loop = asyncio.get_event_loop()

--- a/src/pelicanfs/dir_header_parser.py
+++ b/src/pelicanfs/dir_header_parser.py
@@ -1,9 +1,9 @@
 
-def parse_metalink(headers={}):
+def parse_metalink(headers: dict[str, str]) -> tuple[list[tuple[str, int]], str]:
     """
     Parse the metalink headers to get a list of caches to attempt to try in priority orider
     """
-    linkPrio = []
+    linkPrio: list[tuple[str, int]] = []
 
     if "Link" in headers:
         links = headers["Link"].split(",")
@@ -21,9 +21,22 @@ def parse_metalink(headers={}):
             link = elmts[0].strip(" <>")
 
             linkPrio.append([link, priority])
-
     linkPrio.sort(key=lambda x: x[1])
-    return linkPrio
+
+    # Pull out the namespace information; we'll use this to populate
+    # the namespace prefix cache later
+    namespace = ""
+    for info in headers.get("X-Pelican-Namespace", "").split(","):
+        info = info.strip()
+        pair = info.split("=", 1)
+        if len(pair) < 2:
+            continue
+        key, val = pair
+        if key == "namespace":
+            namespace = val
+            break
+
+    return linkPrio, namespace
 
 def get_dirlist_loc(headers={}):
     """

--- a/test/test_director.py
+++ b/test/test_director.py
@@ -1,0 +1,100 @@
+"""
+Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ 
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License.  You may
+obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+"""
+
+import aiohttp
+import pytest
+import fsspec
+import pelicanfs.core
+from pelicanfs.core import PelicanFileSystem, NoAvailableSource
+
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address():
+    return ("127.0.0.1", 0)
+
+@pytest.fixture(scope="session")
+def httpserver2(httpserver_listen_address, httpserver_ssl_context):
+    host, port = httpserver_listen_address
+    if not host:
+        host = HTTPServer.DEFAULT_LISTEN_HOST
+    if not port:
+        port = HTTPServer.DEFAULT_LISTEN_PORT
+
+    server = HTTPServer(host=host, port=port, ssl_context=httpserver_ssl_context)
+    server.start()
+    yield server
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+def test_open(httpserver: HTTPServer):
+    foo_bar_url = httpserver.url_for("/foo/bar")
+    httpserver.expect_oneshot_request("/foo/bar", method="GET").respond_with_data(
+        "",
+        status=307,
+        headers={"Link": f'<{foo_bar_url}>; rel="duplicate"; pri=1; depth=1',
+                 "Location": foo_bar_url,
+                 "X-Pelican-Namespace": "namespace=/foo"
+                },
+        )
+    httpserver.expect_oneshot_request("/foo/bar", method="HEAD").respond_with_data("hello, world!")
+    httpserver.expect_oneshot_request("/foo/bar", method="GET").respond_with_data("hello, world!")
+
+    pelfs = pelicanfs.core.PelicanFileSystem(httpserver.url_for("/"), skip_instance_cache=True)
+    assert pelfs.cat("/foo/bar") == b"hello, world!"
+
+def test_open_multiple_servers(httpserver: HTTPServer, httpserver2: HTTPServer):
+    foo_bar_url = httpserver2.url_for("/foo/bar")
+    httpserver.expect_oneshot_request("/foo/bar", method="GET").respond_with_data(
+        "",
+        status=307,
+        headers={"Link": f'<{foo_bar_url}>; rel="duplicate"; pri=1; depth=1',
+                 "Location": foo_bar_url,
+                 "X-Pelican-Namespace": "namespace=/foo"
+                },
+        )
+    httpserver2.expect_oneshot_request("/foo/bar", method="HEAD").respond_with_data("hello, world 2")
+    httpserver2.expect_oneshot_request("/foo/bar", method="GET").respond_with_data("hello, world 2")
+
+    pelfs = PelicanFileSystem(httpserver.url_for("/"), skip_instance_cache=True)
+    assert pelfs.cat("/foo/bar") == b"hello, world 2"
+
+def test_open_fallback(httpserver: HTTPServer, httpserver2: HTTPServer):
+    foo_bar_url = httpserver.url_for("/foo/bar")
+    foo_bar_url2 = httpserver2.url_for("/foo/bar")
+    httpserver.expect_oneshot_request("/foo/bar", method="GET").respond_with_data(
+        "",
+        status=307,
+        headers={"Link": f'<{foo_bar_url}>; rel="duplicate"; pri=1; depth=1, '
+                         f'<{foo_bar_url2}>; rel="duplicate"; pri=2; depth=1',
+                 "Location": foo_bar_url,
+                 "X-Pelican-Namespace": "namespace=/foo"
+                },
+        )
+    httpserver2.expect_oneshot_request("/foo/bar", method="HEAD").respond_with_data("hello, world 2")
+    httpserver2.expect_oneshot_request("/foo/bar", method="GET").respond_with_data("hello, world 2")
+    httpserver2.expect_oneshot_request("/foo/bar", method="GET").respond_with_data("hello, world 2")
+
+    pelfs = PelicanFileSystem(httpserver.url_for("/"), skip_instance_cache=True)
+    assert pelfs.cat("/foo/bar") == b"hello, world 2"
+    assert pelfs.cat("/foo/bar") == b"hello, world 2"
+    with pytest.raises(aiohttp.ClientResponseError):
+        pelfs.cat("/foo/bar")
+    with pytest.raises(NoAvailableSource):
+        assert pelfs.cat("/foo/bar")
+

--- a/test/test_osdf.py
+++ b/test/test_osdf.py
@@ -1,0 +1,22 @@
+"""
+Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ 
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License.  You may
+obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+"""
+
+import fsspec
+
+def test_osdf():
+    with fsspec.open("osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt") as of:
+        data = of.read()
+    assert data == b'Hello, World!\n'


### PR DESCRIPTION
This PR adds a cache which tracks information about the various namespace prefixes.

On cache miss, the prefix and the list of endpoints are put into the cache (caching for up to 15 minutes).  This information is reused on subsequent opens of the object.

Additionally, to ease my local testing, this registers the `osdf://` and `pelican://` schemes with fsspec, allowing this to be a valid mini-test:

```
import fsspec
with fsspec.open("osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt") as of:
    print(of.read(1024))
```