### PR TITLE
Fixed 'pelican://' checking in _check_fspath

### DIFF
--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -207,8 +207,8 @@ class PelicanFileSystem(AsyncFileSystem):
 
         if federation_discovery_url and not federation_discovery_url.endswith("/"):
             federation_discovery_url = federation_discovery_url + "/"
-        self.discoveryUrl = federation_discovery_url
-        self.directorUrl = ""
+        self.discovery_url = federation_discovery_url
+        self.director_url = ""
 
         self.direct_reads = direct_reads
         self.preferred_caches = preferred_caches

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -205,8 +205,11 @@ class PelicanFileSystem(AsyncFileSystem):
         # The internal filesystem
         self.http_file_system = fshttp.HTTPFileSystem(asynchronous=asynchronous, loop=loop, **kwargs)
 
-        self.discovery_url = federation_discovery_url
-        self.director_url = ""
+
+        if federation_discovery_url and not federation_discovery_url.endswith('/'):
+            federation_discovery_url = federation_discovery_url + '/'
+        self.discoveryUrl = federation_discovery_url
+        self.directorUrl = ""
 
         self.direct_reads = direct_reads
         self.preferred_caches = preferred_caches
@@ -591,7 +594,10 @@ class PelicanFileSystem(AsyncFileSystem):
         filesystem object and return the path.
         """
         if not path.startswith("/"):
-            pelican_url = urllib.parse.urlparse("pelican://" + path)
+            if path.startswith("pelican://"):
+                pelican_url = urllib.parse.urlparse(path)
+            else:
+                pelican_url = urllib.parse.urlparse("pelican://" + path)
             discovery_url = pelican_url._replace(path="/", fragment="", query="", params="")
             discovery_str = discovery_url.geturl()
             if not self.discovery_url:

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -205,9 +205,8 @@ class PelicanFileSystem(AsyncFileSystem):
         # The internal filesystem
         self.http_file_system = fshttp.HTTPFileSystem(asynchronous=asynchronous, loop=loop, **kwargs)
 
-
-        if federation_discovery_url and not federation_discovery_url.endswith('/'):
-            federation_discovery_url = federation_discovery_url + '/'
+        if federation_discovery_url and not federation_discovery_url.endswith("/"):
+            federation_discovery_url = federation_discovery_url + "/"
         self.discoveryUrl = federation_discovery_url
         self.directorUrl = ""
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pelicanfs.core import PelicanFileSystem, InvalidMetadata
 import pytest
+
+from pelicanfs.core import InvalidMetadata, PelicanFileSystem
 
 
 def test_remove_hostname():
@@ -57,9 +58,9 @@ def test_fspath():
     path = "/aboslute/path"
     assert pelfs._check_fspath(path) == path
 
-    assert pelfs._check_fspath("pelican://test-discovery-url.org/p2/") == '/p2/'
-    
-    assert pelfs._check_fspath("test-discovery-url.org/p3") == '/p3'    
+    assert pelfs._check_fspath("pelican://test-discovery-url.org/p2/") == "/p2/"
+
+    assert pelfs._check_fspath("test-discovery-url.org/p3") == "/p3"
 
     with pytest.raises(InvalidMetadata):
         pelfs._check_fspath("pelican://diff-disc/path")
@@ -67,11 +68,10 @@ def test_fspath():
     with pytest.raises(InvalidMetadata):
         pelfs._check_fspath("not-the-discovery-url.org/p3")
 
-    pelfs_disc = PelicanFileSystem(
-        skip_instance_cache=True
-    )
+    pelfs_disc = PelicanFileSystem(skip_instance_cache=True)
 
     assert pelfs_disc.discovery_url == ""
 
     pelfs_disc._check_fspath("pelican://new-discovery-url.org/p/")
+
     assert pelfs_disc.discovery_url == "pelican://new-discovery-url.org/"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pelicanfs.core import PelicanFileSystem
+from pelicanfs.core import PelicanFileSystem, InvalidMetadata
+import pytest
 
 
 def test_remove_hostname():
@@ -46,3 +47,31 @@ def test_remove_hostname():
 
     # Test a a non-list | string | dict
     assert PelicanFileSystem._remove_host_from_paths(22) == 22
+
+
+def test_fspath():
+    pelfs = PelicanFileSystem(
+        "pelican://test-discovery-url.org",
+        skip_instance_cache=True,
+    )
+    path = "/aboslute/path"
+    assert pelfs._check_fspath(path) == path
+
+    assert pelfs._check_fspath("pelican://test-discovery-url.org/p2/") == '/p2/'
+    
+    assert pelfs._check_fspath("test-discovery-url.org/p3") == '/p3'    
+
+    with pytest.raises(InvalidMetadata):
+        pelfs._check_fspath("pelican://diff-disc/path")
+
+    with pytest.raises(InvalidMetadata):
+        pelfs._check_fspath("not-the-discovery-url.org/p3")
+
+    pelfs_disc = PelicanFileSystem(
+        skip_instance_cache=True
+    )
+
+    assert pelfs_disc.discovery_url == ""
+
+    pelfs_disc._check_fspath("pelican://new-discovery-url.org/p/")
+    assert pelfs_disc.discovery_url == "pelican://new-discovery-url.org/"


### PR DESCRIPTION
I believe this will close #54 

The previous version wasn't properly working with any urls which already had  the "pelican://" scheme to it.

@bbockelm Please correct this if I misinterpreted what the function was supposed to do.