### PR TITLE
Test multiple Python versions in CI

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python3 -m pip install '.[testing]'
+        python -m pip install '.[testing]'
     - name: Test with pytest
       run: pytest

--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -9,8 +9,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12"]
-
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
It would be great to extend the current CI to test all supported Python versions, to prevent accidental breakages as development continues.