### PR TITLE
Disable automaticlly redirect in get_dir_url

### DIFF
--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -318,7 +318,7 @@ class PelicanFileSystem(AsyncFileSystem):
         # Timeout response in seconds - the default response is 5 minutes
         timeout = aiohttp.ClientTimeout(total=5)
         session = await self.httpFileSystem.set_session()
-        async with session.request('PROPFIND', url, timeout=timeout) as resp:
+        async with session.request('PROPFIND', url, timeout=timeout, allow_redirects = False) as resp:
             if 'Link' not in resp.headers:
                 raise BadDirectorResponse()
             dirlist_url = parse_metalink(resp.headers)[0][0][0]


### PR DESCRIPTION
When try to access my data on origin, raise BadDirectorResponse().
After checking, Justin and I found it was caused by automatically redirect to origin, then it return metalink of origin, which do not contain "Link". 
After disable redirects, it works correctly.