### PR TITLE
Add MANIFEST.in to ensure tests are bundled in sdist

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,6 +23,10 @@ jobs:
         --user
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+    - name: List the files in the tarball
+      run: python3 -m tarfile --list dist/*.tar.*
+    - name: List the files in the wheel
+      run: python3 -m zipfile --list dist/*.whl
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -22,6 +22,10 @@ jobs:
         --user
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+    - name: List the files in the tarball
+      run: python3 -m tarfile --list dist/*.tar.*
+    - name: List the files in the wheel
+      run: python3 -m zipfile --list dist/*.whl
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include test *.py *.xml


### PR DESCRIPTION
This PR adds a `MANIFEST.in` file to ensure that the necessary test configuration and data files are included in the tarball.

I think they weren't included because `test/` isn't recognised as a Python package (no `__init__.py`).