### PR TITLE
Expose public API objects at the top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install -e .
 To use pelicanfs, first create a `PelicanFileSystem` and provide it with the pelican federation url. As an example using the OSDF federation
 
 ```python
-from pelicanfs.core import PelicanFileSystem
+from pelicanfs import PelicanFileSystem
 
 pelfs = PelicanFileSystem("pelican://osg-htc.org")
 ```
@@ -50,7 +50,7 @@ print(hello_world)
 Sometimes various systems that interact with an fsspec want a key-value mapper rather than a url. To do that, call the `PelicanMap` function with the namespace path and a `PelicanFileSystem` object rather than using the fsspec `get_mapper` call. For example:
 
 ```python
-from pelicanfs.core import PelicanFileSystem, PelicanMap
+from pelicanfs import PelicanFileSystem, PelicanMap
 
 pelfs = PelicanFileSystem("some-director-url")
 file1 = PelicanMap("/namespace/file/1", pelfs=pelfs)

--- a/examples/pelicanfs_example.ipynb
+++ b/examples/pelicanfs_example.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pelicanfs.core import PelicanFileSystem, PelicanMap, OSDFFileSystem"
+    "from pelicanfs import PelicanFileSystem, PelicanMap, OSDFFileSystem"
    ]
   },
   {

--- a/examples/xarray/XArrayWithFSSpec.ipynb
+++ b/examples/xarray/XArrayWithFSSpec.ipynb
@@ -39,7 +39,7 @@
     "import cartopy.feature as cfeature\n",
     "import metpy.calc as mpcalc\n",
     "from metpy.units import units\n",
-    "from pelicanfs.core import OSDFFileSystem"
+    "from pelicanfs import OSDFFileSystem"
    ]
   },
   {

--- a/src/pelicanfs/__init__.py
+++ b/src/pelicanfs/__init__.py
@@ -1,0 +1,21 @@
+"""
+Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License.  You may
+obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .core import (
+    OSDFFileSystem,
+    PelicanFileSystem,
+    PelicanMap,
+)


### PR DESCRIPTION
This PR just adds imports of the public API `.core` objects in the `pelicanfs` init module, so that the standard user interface is

```python
from pelicanfs import PelicanFileSystem
```

i.e. without the `.core` module. This makes the user experience a tiny bit nicer, IMO.