### PR TITLE
Relax Python version requirement to allow 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pelicanfs"
-version = "1.2.3"
+version = "1.2.4"
 description = "An FSSpec Implementation using the Pelican System"
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,12 +22,13 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-requires-python = ">=3.12, <4"
+requires-python = ">=3.11, <4"
 dependencies = [
     "aiohttp >=3.9.4,<4",
     "aiowebdav2",


### PR DESCRIPTION
As mentioned in the linked issue, I wasn't able to determine that 3.12 is actually a hard requirement for this library.

After double checking a few things with @turetske, we think `3.11` should work, but it is definitely the floor (the `aiowebdav2` library requires at least `3.11`)

This relaxes the version requirement and bumps the `pelicanfs` release number in preparation for another release. 