### PR TITLE
Add pyright linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
     -   id: black
         language_version: python3.12
         args: ["--line-length=200"]
+-   repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.391
+    hooks:
+    -   id: pyright
 
 # Global exclusion for all hooks
 exclude: ^examples/

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["src"],
+  "typeCheckingMode": "basic",
+  "reportMissingTypeStubs": false,
+  "reportMissingImports": false,
+  "reportUnknownMemberType": false,
+  "reportUnknownArgumentType": false,
+  "reportUnknownVariableType": false,
+  "reportIncompatibleMethodOverride": false,
+  "reportAttributeAccessIssue": "warning"
+}

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -395,7 +395,7 @@ class PelicanFileSystem(AsyncFileSystem):
         if session:
             session.headers["Authorization"] = f"Bearer {token}"
 
-    async def _handle_token_generation(self, url: str, director_response: DirectorResponse, operation: TokenOperation) -> str:
+    async def _handle_token_generation(self, url: str, director_response: DirectorResponse, operation: TokenOperation) -> Optional[str]:
         """
         Handle token generation if required by the director response.
 
@@ -521,10 +521,10 @@ class PelicanFileSystem(AsyncFileSystem):
         fparsed = urllib.parse.urlparse(fileloc)
         # Removing the query if need be
         try:
-            cache_url, director_response = self._match_namespace(fparsed.path)
-            if cache_url:
-                logger.debug(f"Found previously working cache: {cache_url}")
-                return cache_url, director_response
+            cached_url, cached_director_response = self._match_namespace(fparsed.path)
+            if cached_url:
+                logger.debug(f"Found previously working cache: {cached_url}")
+                return cached_url, cached_director_response
         except NoAvailableSource:
             # Namespace exists but cache list is empty (e.g., from get_dirlist_url caching)
             # Fall through to discover caches
@@ -554,15 +554,15 @@ class PelicanFileSystem(AsyncFileSystem):
                 new_caches = [urllib.parse.urlparse(server)._replace(query=fparsed.query).geturl() for server in director_response.object_servers]
                 for cache in old_cache_list:
                     if cache == "+":
-                        for cache_url in new_caches:
-                            if cache_url not in cache_set:
-                                cache_set.add(cache_url)
-                                cache_list.append(cache_url)
+                        for new_cache_url in new_caches:
+                            if new_cache_url not in cache_set:
+                                cache_set.add(new_cache_url)
+                                cache_list.append(new_cache_url)
                     else:
-                        cache_set.add(cache_url)
+                        cache_set.add(cache)
                         cache_list.append(cache)
-            if not cache_list:
-                cache_list = new_caches
+                if not cache_list:
+                    cache_list = new_caches
         else:
             # Use director-provided caches
             cache_list = [urllib.parse.urlparse(server)._replace(query=fparsed.query).geturl() for server in director_response.object_servers]
@@ -611,10 +611,11 @@ class PelicanFileSystem(AsyncFileSystem):
             logger.error("No working cache found")
             raise NoAvailableSource()
 
+        working_url = cache_list[0]
         with self._namespace_lock:
             self._namespace_cache[namespace] = _CacheManager(cache_list, director_response)
 
-        return updated_url, director_response
+        return working_url, director_response
 
     async def get_origin_url(self, fileloc: str) -> Tuple[str, DirectorResponse]:
         """
@@ -630,7 +631,7 @@ class PelicanFileSystem(AsyncFileSystem):
 
         return origin, director_response
 
-    async def _set_director_url(self) -> str:
+    async def _set_director_url(self) -> None:
         if not self.director_url:
             metadata_json = await self._discover_federation_metadata(self.discovery_url)
             # Ensure the director url has a '/' at the end
@@ -739,6 +740,7 @@ class PelicanFileSystem(AsyncFileSystem):
             return
         namespace_info.cache_manager.bad_cache(bad_cache)
 
+    @staticmethod
     def _dirlist_dec(func):
         """
         Decorator function which, when given a namespace location, get the url for the dirlist location from the headers
@@ -1088,9 +1090,9 @@ class PelicanFileSystem(AsyncFileSystem):
             raise NotImplementedError("Write mode is not supported for open(). Use put() or pipe() to write files.")
 
         if self.direct_reads:
-            data_url, director_response = sync(self.loop, self.get_origin_url, path)
+            data_url, director_response = sync(self.loop, self.get_origin_url, path)  # type: ignore[misc]
         else:
-            data_url, director_response = sync(self.loop, self.get_working_cache, path)
+            data_url, director_response = sync(self.loop, self.get_working_cache, path)  # type: ignore[misc]
 
         # Handle token generation if required
         operation = self._get_token_operation("open")
@@ -1128,6 +1130,7 @@ class PelicanFileSystem(AsyncFileSystem):
             self._access_stats.add_response(path, ar)
         return fp
 
+    @staticmethod
     def _cache_dec(func):
         """
         Decorator function which, when given a namespace location, finds the best working cache that serves the namespace,
@@ -1164,6 +1167,7 @@ class PelicanFileSystem(AsyncFileSystem):
 
         return wrapper
 
+    @staticmethod
     def _cache_multi_dec(func):
         """
         Decorator function which, when given a list of namespace location, finds the best working cache that serves the namespace,

--- a/src/pelicanfs/token_content_iterator.py
+++ b/src/pelicanfs/token_content_iterator.py
@@ -117,8 +117,8 @@ class TokenContentIterator:
         index (int): Internal index of the current fallback cred_location
     """
 
-    location: str
-    name: str
+    location: Optional[str] = None
+    name: Optional[str] = None
     operation: Optional[object] = None
     destination_url: Optional[str] = None
     pelican_url: Optional[str] = None
@@ -215,7 +215,7 @@ class TokenContentIterator:
                         # Non-blocking read with timeout
                         import msvcrt
 
-                        if msvcrt.kbhit() or process.stdout:
+                        if process.stdout and (msvcrt.kbhit() or process.stdout):
                             return process.stdout.read(self.pty_buffer_size)
                         return b""
                     except Exception:
@@ -489,7 +489,8 @@ class TokenContentIterator:
                                 logger.warning(f"Error reading token from {token_path}: {err}")
 
                 case TokenDiscoveryMethod.HTCONDOR_DISCOVERY:
-                    self.cred_locations = self.discoverHTCondorTokenLocations(self.name)
+                    if self.name:
+                        self.cred_locations = self.discoverHTCondorTokenLocations(self.name)
                     # HTCONDOR_FALLBACK will be handled in the next iteration
 
                 case TokenDiscoveryMethod.HTCONDOR_FALLBACK:

--- a/src/pelicanfs/token_generator.py
+++ b/src/pelicanfs/token_generator.py
@@ -23,6 +23,7 @@ from urllib.parse import ParseResult, urlparse
 
 from scitokens import SciToken
 
+from pelicanfs.dir_header_parser import DirectorResponse
 from pelicanfs.exceptions import (
     InvalidDestinationURL,
     NoCredentialsException,
@@ -66,7 +67,7 @@ class TokenGenerator:
     def __init__(
         self,
         destination_url: str,
-        dir_resp: object,
+        dir_resp: Optional[DirectorResponse],
         operation: TokenOperation,
         token_name: Optional[str] = None,
         pelican_url: Optional[str] = None,
@@ -74,7 +75,7 @@ class TokenGenerator:
         pty_buffer_size: int = 1024,
         select_timeout: float = 0.1,
     ) -> None:
-        self.DirResp: object = dir_resp
+        self.DirResp: Optional[DirectorResponse] = dir_resp
         self.DestinationURL: str = destination_url
         self.PelicanURL: Optional[str] = pelican_url
         self.TokenName: Optional[str] = token_name
@@ -207,7 +208,7 @@ def _is_path_prefix(object_name: str, resource: str) -> bool:
 def token_is_valid_and_acceptable(
     jwt_serialized: str,
     object_name: str,
-    dir_resp: object,
+    dir_resp: Optional[DirectorResponse],
     operation: TokenOperation,
 ) -> Tuple[bool, datetime]:
     """
@@ -258,7 +259,7 @@ def token_is_valid_and_acceptable(
     logger.debug(f"Required scopes for operation '{operation}': {ok_scopes}")
     logger.debug(f"Token scopes: {token.get('scope')}")
 
-    token_scopes = token.get("scope", "")
+    token_scopes = token.get("scope") or ""
     scope_list = token_scopes.split()
     acceptable_scope = False
 


### PR DESCRIPTION
Add a pyright linter for pelicanfs. This will hopefully catch failures some unassigned bug values that we couldn't have caught before.

Because this is a new linter, there are a lot of small changes made to the files to address linting issues. Also a few cases where the linter is specifically told to ignore some lines.