### PR TITLE
Propagate kwargs from _ls and _ls_from_http to _ls_real

### DIFF
--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -768,7 +768,7 @@ class PelicanFileSystem(AsyncFileSystem):
         if self.use_listings_cache and path in self.dircache:
             out = self.dircache[path]
         else:
-            out = await self._ls_real(path, detail=detail)
+            out = await self._ls_real(path, detail=detail, **kwargs)
             self.dircache[path] = out
         return self._remove_host_from_paths(out)
 
@@ -794,7 +794,7 @@ class PelicanFileSystem(AsyncFileSystem):
         if self.use_listings_cache and collections_url in self.dircache:
             out = self.dircache[collections_url]
         else:
-            out = await self._ls_real(collections_url, detail=detail)
+            out = await self._ls_real(collections_url, detail=detail, **kwargs)
             self.dircache[collections_url] = out
         return out
 


### PR DESCRIPTION
This PR patches the `PelicanFileSystem._ls` and `PelicanFileSystem._ls_from_http`  methods to propagate any `**kwargs` to the `PelicanFileSystem._ls_real` method.

This is required to reuse an open WebDAV client for all subsequent operations (via the `client` keyword), which significantly speeds up long walks.