### PR TITLE
Oauth jupyter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "cachetools >=5.3,<6",
     "fsspec >=2024.3.1",
     "igwn-auth-utils",
-    "pywinpty; platform_system=='Windows'",
+    "pexpect; platform_system!='Windows'",
+    "wexpect; platform_system=='Windows'",
 ]
 
 [project.entry-points."fsspec.specs"]

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -242,8 +242,6 @@ class PelicanFileSystem(AsyncFileSystem):
         loop=None,
         get_webdav_client=get_webdav_client,
         oidc_timeout_seconds=300,
-        pty_buffer_size=1024,
-        select_timeout=0.1,
         **kwargs,
     ):
         super().__init__(self, asynchronous=asynchronous, loop=loop, **kwargs)
@@ -259,7 +257,10 @@ class PelicanFileSystem(AsyncFileSystem):
         self.use_listings_cache = request_options.pop("use_listings_cache", False)
 
         # The internal filesystem
-        self.http_file_system = fshttp.HTTPFileSystem(asynchronous=asynchronous, loop=loop, **kwargs)
+        # IMPORTANT: We need to disable caching for HTTPFileSystem to avoid shared state
+        # issues. Without skip_instance_cache=True, multiple PelicanFileSystem instances
+        # could share the same HTTPFileSystem, causing method binding conflicts.
+        self.http_file_system = fshttp.HTTPFileSystem(asynchronous=asynchronous, loop=loop, skip_instance_cache=True, **kwargs)
 
         if federation_discovery_url and not federation_discovery_url.endswith("/"):
             federation_discovery_url = federation_discovery_url + "/"
@@ -271,8 +272,6 @@ class PelicanFileSystem(AsyncFileSystem):
 
         # OIDC device flow configuration
         self.oidc_timeout_seconds = oidc_timeout_seconds
-        self.pty_buffer_size = pty_buffer_size
-        self.select_timeout = select_timeout
 
         # These are all not implemented in the http fsspec and as such are not implemented in the pelican fsspec
         # They will raise NotImplementedErrors when called
@@ -373,27 +372,23 @@ class PelicanFileSystem(AsyncFileSystem):
 
     def _set_http_filesystem_token(self, token: str, session=None) -> None:
         """
-        Set the Authorization header in the HTTP filesystem's session.
+        Set the Authorization header in the HTTP filesystem for all future requests.
 
         Args:
             token: The token to set (without "Bearer " prefix)
-            session: Optional specific session to set token in (in addition to HTTP filesystem session)
+            session: Optional specific session to set token in (in addition to HTTP filesystem)
         """
         if not token:
             return
 
-        # Set the token in the HTTP filesystem's session headers
-        if hasattr(self.http_file_system, "session") and self.http_file_system.session:
-            self.http_file_system.session.headers.update({"Authorization": f"Bearer {token}"})
-        else:
-            # If session doesn't exist yet, set it in the default headers
-            if not hasattr(self.http_file_system, "_default_headers"):
-                self.http_file_system._default_headers = {}
-            self.http_file_system._default_headers["Authorization"] = f"Bearer {token}"
+        auth_header = f"Bearer {token}"
 
-        # Also set token in the specific session if provided
-        if session:
-            session.headers["Authorization"] = f"Bearer {token}"
+        # Set the token in http_file_system.kwargs which is used for all requests
+        # HTTPFileSystem copies self.kwargs for each request (kw = self.kwargs.copy())
+        if hasattr(self.http_file_system, "kwargs"):
+            if "headers" not in self.http_file_system.kwargs:
+                self.http_file_system.kwargs["headers"] = {}
+            self.http_file_system.kwargs["headers"]["Authorization"] = auth_header
 
     async def _handle_token_generation(self, url: str, director_response: DirectorResponse, operation: TokenOperation) -> str:
         """
@@ -413,12 +408,17 @@ class PelicanFileSystem(AsyncFileSystem):
         if not director_response.x_pel_ns_hdr.require_token:
             return None
 
-        # Check if we already have a token from kwargs headers
+        # Check if we already have a token from kwargs headers or previous acquisition
         existing_token = self._get_token()
+        logger.debug(f"_handle_token_generation called for url={url[:50] if url else None}...")
+        logger.debug(f"  self.token={self.token[:30] if self.token else None}...")
+        logger.debug(f"  existing_token={existing_token[:20] if existing_token else None}...")
         if existing_token:
-            logger.debug(f"Using existing token from headers for {url}")
+            logger.debug("  Returning existing token (no new token generation needed)")
             self._set_http_filesystem_token(existing_token)
             return existing_token
+
+        logger.debug("  No existing token found, will generate new token via TokenGenerator")
 
         try:
             # Ensure director URL is set (for token generation validation)
@@ -437,7 +437,6 @@ class PelicanFileSystem(AsyncFileSystem):
 
                 # Construct pelican://<federation-host>/<path>
                 pelican_url = f"pelican://{federation_host}{path}"
-                logger.debug(f"Constructed pelican URL for token generation: {pelican_url}")
 
             # Create token generator with OIDC configuration
             token_generator = TokenGenerator(
@@ -446,19 +445,27 @@ class PelicanFileSystem(AsyncFileSystem):
                 operation=operation,
                 pelican_url=pelican_url,
                 oidc_timeout_seconds=self.oidc_timeout_seconds,
-                pty_buffer_size=self.pty_buffer_size,
-                select_timeout=self.select_timeout,
             )
 
             # Get token (TokenContentIterator will automatically discover token location)
             token = token_generator.get_token()
+            logger.debug(f"  token_generator.get_token() returned: type={type(token).__name__}, len={len(token) if token else 0}, value={token[:20] if token else None}...")
             if token:
                 self._set_http_filesystem_token(token)
                 # Also update self.token so _ls_real can use it
                 self.token = f"Bearer {token}"
+                logger.debug(f"  SUCCESS: Set self.token = Bearer {token[:20]}...")
+                # Verify token was actually set
+                verify_token = self._get_token()
+                logger.debug(f"  VERIFY: self._get_token() returns: {verify_token[:20] if verify_token else None}...")
+            else:
+                logger.warning(f"  WARNING: token_generator.get_token() returned falsy value: {repr(token)}")
             return token
         except Exception as e:
             logger.warning(f"Failed to generate token for {url}: {e}")
+            import traceback
+
+            logger.debug(f"  Exception traceback: {traceback.format_exc()}")
             return None
 
     def get_access_data(self):
@@ -574,22 +581,26 @@ class PelicanFileSystem(AsyncFileSystem):
             logger.debug("Finding a working cache...")
             session = await self.http_file_system.set_session()
 
+            # Build request headers
+            request_headers = {}
+
             # Handle token generation for cache requests if required
             if director_response.x_pel_ns_hdr and director_response.x_pel_ns_hdr.require_token:
+                logger.debug(f"get_working_cache: Token is required, self.token before generation: {self.token[:30] if self.token else None}...")
                 operation = self._get_token_operation("get_working_cache")
                 await self._handle_token_generation(updated_url, director_response, operation)
+                logger.debug(f"get_working_cache: self.token AFTER _handle_token_generation: {self.token[:30] if self.token else None}...")
 
-                # Set token in session headers if we have one (either existing or newly generated)
+                # Get the token to use for this request
                 token_to_use = self._get_token()
+                logger.debug(f"get_working_cache: token_to_use from _get_token(): {token_to_use[:20] if token_to_use else None}...")
                 if token_to_use:
-                    self._set_http_filesystem_token(token_to_use, session)
-                else:
-                    pass
-            else:
-                pass
+                    self._set_http_filesystem_token(token_to_use)
+                    request_headers["Authorization"] = f"Bearer {token_to_use}"
+
             try:
                 logger.debug(f"Checking to see if the cache at {updated_url} is working and returns a valid response code")
-                async with session.head(updated_url, timeout=timeout) as resp:
+                async with session.head(updated_url, timeout=timeout, headers=request_headers if request_headers else None) as resp:
                     # Accept both successful responses (2xx/3xx) and 404 (object doesn't exist)
                     # as indicators that the cache is working. Other error codes indicate
                     # the cache itself is having problems.
@@ -779,6 +790,9 @@ class PelicanFileSystem(AsyncFileSystem):
         Note: We do NOT remove hosts from the results because HTTPFileSystem needs
         full URLs to download files.
         """
+        logger.debug(f"_ls_from_http: Called with url={url[:60] if url else None}...")
+        logger.debug(f"_ls_from_http: self id={id(self)}, self.token at entry: {self.token[:30] if self.token else None}...")
+
         # Extract the path from the URL
         parsed = urllib.parse.urlparse(url)
         path = parsed.path
@@ -786,9 +800,13 @@ class PelicanFileSystem(AsyncFileSystem):
         # Get the collections URL for this path
         collections_url, director_response = await self.get_dirlist_url(path)
 
+        logger.debug(f"_ls_from_http: self.token after get_dirlist_url: {self.token[:30] if self.token else None}...")
+
         # Handle token generation if required
         operation = self._get_token_operation("_ls")
-        self._handle_token_generation(collections_url, director_response, operation)
+        await self._handle_token_generation(collections_url, director_response, operation)
+
+        logger.debug(f"_ls_from_http: self.token after _handle_token_generation: {self.token[:30] if self.token else None}...")
 
         # Call _ls_real with the collections URL
         if self.use_listings_cache and collections_url in self.dircache:

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -1266,10 +1266,117 @@ class PelicanFileSystem(AsyncFileSystem):
         results = await self.http_file_system._info(path, **kwargs)
         return self._remove_host_from_paths(results)
 
-    @_cache_dec
-    async def _get(self, rpath, lpath, **kwargs):
-        results = await self.http_file_system._get(rpath, lpath, **kwargs)
-        return self._remove_host_from_paths(results)
+    async def _get(self, rpath, lpath, recursive=False, callback=None, maxdepth=None, **kwargs):
+        """
+        Copy file(s) to local.
+
+        This override is necessary because the base fsspec _get method only filters out
+        directories when `not recursive or maxdepth is not None`. When `recursive=True`
+        without maxdepth, directories are passed to _get_file which tries to GET them,
+        causing 403 errors on cache servers that don't serve directories via GET.
+        """
+        import os
+        from glob import has_magic
+
+        from fsspec.callbacks import DEFAULT_CALLBACK
+        from fsspec.implementations.local import (
+            LocalFileSystem,
+            make_path_posix,
+            trailing_sep,
+        )
+        from fsspec.utils import other_paths
+
+        if callback is None:
+            callback = DEFAULT_CALLBACK
+
+        path = self._check_fspath(rpath)
+        logger.debug(f"_get: Starting for path={path}, recursive={recursive}")
+        logger.debug(f"_get: self id={id(self)}, self.token before get_working_cache: {self.token[:30] if self.token else None}...")
+
+        if self.direct_reads:
+            data_url, director_response = await self.get_origin_url(path)
+        else:
+            data_url, director_response = await self.get_working_cache(path)
+
+        logger.debug(f"_get: self.token AFTER get_working_cache: {self.token[:30] if self.token else None}...")
+
+        # Handle token generation if required
+        operation = self._get_token_operation("_get")
+        await self._handle_token_generation(data_url, director_response, operation)
+
+        logger.debug(f"_get: self id={id(self)}, self.token AFTER _handle_token_generation: {self.token[:30] if self.token else None}...")
+        logger.debug("_get: About to call _expand_path")
+        logger.debug(f"_get: http_file_system._ls = {self.http_file_system._ls}")
+        logger.debug(f"_get: http_file_system._ls.__self__ id = {id(self.http_file_system._ls.__self__) if hasattr(self.http_file_system._ls, '__self__') else 'N/A'}")
+        logger.debug(f"_get: expected self._ls_from_http = {self._ls_from_http}")
+        logger.debug(f"_get: expected self._ls_from_http.__self__ id = {id(self._ls_from_http.__self__) if hasattr(self._ls_from_http, '__self__') else 'N/A'}")
+
+        # Now perform the actual _get logic with directory filtering
+        if isinstance(lpath, list) and isinstance(rpath, list):
+            # No need to expand paths when both source and destination
+            # are provided as lists
+            rpaths = rpath
+            lpaths = lpath
+        else:
+            source_is_str = isinstance(rpath, str)
+            # First check for rpath trailing slash as _strip_protocol removes it
+            source_not_trailing_sep = source_is_str and not trailing_sep(rpath)
+
+            # Use the data_url (cache URL) for expansion
+            rpaths = await self.http_file_system._expand_path(data_url, recursive=recursive, maxdepth=maxdepth)
+
+            # CRITICAL FIX: Always filter out directories to prevent 403 errors
+            # when trying to GET a directory from the cache server.
+            # The base fsspec only filters when `not recursive or maxdepth is not None`,
+            # but cache servers return 403 for directory GET requests.
+            if source_is_str:
+                filtered_rpaths = []
+                for p in rpaths:
+                    if trailing_sep(p):
+                        continue
+                    is_dir = await self.http_file_system._isdir(p)
+                    if is_dir:
+                        continue
+                    filtered_rpaths.append(p)
+                rpaths = filtered_rpaths
+                if not rpaths:
+                    return
+
+            lpath = make_path_posix(lpath)
+            source_is_file = len(rpaths) == 1
+            dest_is_dir = isinstance(lpath, str) and (trailing_sep(lpath) or LocalFileSystem().isdir(lpath))
+
+            exists = source_is_str and ((has_magic(data_url) and source_is_file) or (not has_magic(data_url) and dest_is_dir and source_not_trailing_sep))
+            lpaths = other_paths(
+                rpaths,
+                lpath,
+                exists=exists,
+                flatten=not source_is_str,
+            )
+
+        [os.makedirs(os.path.dirname(lp), exist_ok=True) for lp in lpaths]
+        batch_size = kwargs.pop("batch_size", self.http_file_system.batch_size)
+
+        from fsspec.asyn import _run_coros_in_chunks
+
+        coros = []
+        callback.set_size(len(lpaths))
+        for lp, rp in zip(lpaths, rpaths):
+            get_file = callback.branch_coro(self.http_file_system._get_file)
+            coros.append(get_file(rp, lp, **kwargs))
+
+        try:
+            results = await _run_coros_in_chunks(coros, batch_size=batch_size, callback=callback)
+        except Exception as e:
+            if not self.direct_reads:
+                self._bad_cache(data_url, e)
+            raise
+
+        if not self.direct_reads:
+            ar = _AccessResp(data_url, True)
+            self._access_stats.add_response(path, ar)
+
+        return self._remove_host_from_paths(results) if results else None
 
     @_cache_multi_dec
     async def _cat(self, path, recursive=False, on_error="raise", batch_size=None, **kwargs):

--- a/src/pelicanfs/core.py
+++ b/src/pelicanfs/core.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License.  You may
@@ -47,6 +47,7 @@ from .exceptions import (
     NoAvailableSource,
     NoCollectionsUrl,
 )
+from .log_utils import format_token_for_log, trace
 from .token_generator import TokenGenerator, TokenOperation
 
 logger = logging.getLogger("fsspec.pelican")
@@ -370,13 +371,12 @@ class PelicanFileSystem(AsyncFileSystem):
             # Default to read for unknown operations
             return TokenOperation.TokenRead
 
-    def _set_http_filesystem_token(self, token: str, session=None) -> None:
+    def _set_http_filesystem_token(self, token: str) -> None:
         """
         Set the Authorization header in the HTTP filesystem for all future requests.
 
         Args:
             token: The token to set (without "Bearer " prefix)
-            session: Optional specific session to set token in (in addition to HTTP filesystem)
         """
         if not token:
             return
@@ -410,15 +410,15 @@ class PelicanFileSystem(AsyncFileSystem):
 
         # Check if we already have a token from kwargs headers or previous acquisition
         existing_token = self._get_token()
-        logger.debug(f"_handle_token_generation called for url={url[:50] if url else None}...")
-        logger.debug(f"  self.token={self.token[:30] if self.token else None}...")
-        logger.debug(f"  existing_token={existing_token[:20] if existing_token else None}...")
+        trace(logger, "_handle_token_generation url=%s", url[:50] if url else None)
+        trace(logger, "self.token=%s", format_token_for_log(self.token))
+        trace(logger, "existing_token=%s", format_token_for_log(existing_token))
         if existing_token:
-            logger.debug("  Returning existing token (no new token generation needed)")
+            trace(logger, "reusing existing token")
             self._set_http_filesystem_token(existing_token)
             return existing_token
 
-        logger.debug("  No existing token found, will generate new token via TokenGenerator")
+        trace(logger, "no existing token; generating via TokenGenerator")
 
         try:
             # Ensure director URL is set (for token generation validation)
@@ -449,23 +449,24 @@ class PelicanFileSystem(AsyncFileSystem):
 
             # Get token (TokenContentIterator will automatically discover token location)
             token = token_generator.get_token()
-            logger.debug(f"  token_generator.get_token() returned: type={type(token).__name__}, len={len(token) if token else 0}, value={token[:20] if token else None}...")
+            trace(
+                logger,
+                "token_generator.get_token returned len=%s jwt=%s",
+                len(token) if token else 0,
+                format_token_for_log(token),
+            )
             if token:
                 self._set_http_filesystem_token(token)
                 # Also update self.token so _ls_real can use it
                 self.token = f"Bearer {token}"
-                logger.debug(f"  SUCCESS: Set self.token = Bearer {token[:20]}...")
-                # Verify token was actually set
-                verify_token = self._get_token()
-                logger.debug(f"  VERIFY: self._get_token() returns: {verify_token[:20] if verify_token else None}...")
+                trace(logger, "set self.token jwt=%s", format_token_for_log(self.token))
+                trace(logger, "_get_token after set=%s", format_token_for_log(self._get_token()))
             else:
-                logger.warning(f"  WARNING: token_generator.get_token() returned falsy value: {repr(token)}")
+                logger.warning("token_generator.get_token returned falsy value: %r", token)
             return token
         except Exception as e:
             logger.warning(f"Failed to generate token for {url}: {e}")
-            import traceback
-
-            logger.debug(f"  Exception traceback: {traceback.format_exc()}")
+            trace(logger, "token generation failed", exc_info=True)
             return None
 
     def get_access_data(self):
@@ -586,14 +587,14 @@ class PelicanFileSystem(AsyncFileSystem):
 
             # Handle token generation for cache requests if required
             if director_response.x_pel_ns_hdr and director_response.x_pel_ns_hdr.require_token:
-                logger.debug(f"get_working_cache: Token is required, self.token before generation: {self.token[:30] if self.token else None}...")
+                trace(logger, "get_working_cache token before generation=%s", format_token_for_log(self.token))
                 operation = self._get_token_operation("get_working_cache")
                 await self._handle_token_generation(updated_url, director_response, operation)
-                logger.debug(f"get_working_cache: self.token AFTER _handle_token_generation: {self.token[:30] if self.token else None}...")
+                trace(logger, "get_working_cache token after generation=%s", format_token_for_log(self.token))
 
                 # Get the token to use for this request
                 token_to_use = self._get_token()
-                logger.debug(f"get_working_cache: token_to_use from _get_token(): {token_to_use[:20] if token_to_use else None}...")
+                trace(logger, "get_working_cache token_to_use=%s", format_token_for_log(token_to_use))
                 if token_to_use:
                     self._set_http_filesystem_token(token_to_use)
                     request_headers["Authorization"] = f"Bearer {token_to_use}"
@@ -790,8 +791,8 @@ class PelicanFileSystem(AsyncFileSystem):
         Note: We do NOT remove hosts from the results because HTTPFileSystem needs
         full URLs to download files.
         """
-        logger.debug(f"_ls_from_http: Called with url={url[:60] if url else None}...")
-        logger.debug(f"_ls_from_http: self id={id(self)}, self.token at entry: {self.token[:30] if self.token else None}...")
+        trace(logger, "_ls_from_http url=%s", url[:60] if url else None)
+        trace(logger, "_ls_from_http token at entry=%s", format_token_for_log(self.token))
 
         # Extract the path from the URL
         parsed = urllib.parse.urlparse(url)
@@ -800,13 +801,13 @@ class PelicanFileSystem(AsyncFileSystem):
         # Get the collections URL for this path
         collections_url, director_response = await self.get_dirlist_url(path)
 
-        logger.debug(f"_ls_from_http: self.token after get_dirlist_url: {self.token[:30] if self.token else None}...")
+        trace(logger, "_ls_from_http token after get_dirlist_url=%s", format_token_for_log(self.token))
 
         # Handle token generation if required
         operation = self._get_token_operation("_ls")
         await self._handle_token_generation(collections_url, director_response, operation)
 
-        logger.debug(f"_ls_from_http: self.token after _handle_token_generation: {self.token[:30] if self.token else None}...")
+        trace(logger, "_ls_from_http token after generation=%s", format_token_for_log(self.token))
 
         # Call _ls_real with the collections URL
         if self.use_listings_cache and collections_url in self.dircache:
@@ -1290,26 +1291,22 @@ class PelicanFileSystem(AsyncFileSystem):
             callback = DEFAULT_CALLBACK
 
         path = self._check_fspath(rpath)
-        logger.debug(f"_get: Starting for path={path}, recursive={recursive}")
-        logger.debug(f"_get: self id={id(self)}, self.token before get_working_cache: {self.token[:30] if self.token else None}...")
+        trace(logger, "_get path=%s recursive=%s", path, recursive)
+        trace(logger, "_get token before get_working_cache=%s", format_token_for_log(self.token))
 
         if self.direct_reads:
             data_url, director_response = await self.get_origin_url(path)
         else:
             data_url, director_response = await self.get_working_cache(path)
 
-        logger.debug(f"_get: self.token AFTER get_working_cache: {self.token[:30] if self.token else None}...")
+        trace(logger, "_get token after get_working_cache=%s", format_token_for_log(self.token))
 
         # Handle token generation if required
         operation = self._get_token_operation("_get")
         await self._handle_token_generation(data_url, director_response, operation)
 
-        logger.debug(f"_get: self id={id(self)}, self.token AFTER _handle_token_generation: {self.token[:30] if self.token else None}...")
-        logger.debug("_get: About to call _expand_path")
-        logger.debug(f"_get: http_file_system._ls = {self.http_file_system._ls}")
-        logger.debug(f"_get: http_file_system._ls.__self__ id = {id(self.http_file_system._ls.__self__) if hasattr(self.http_file_system._ls, '__self__') else 'N/A'}")
-        logger.debug(f"_get: expected self._ls_from_http = {self._ls_from_http}")
-        logger.debug(f"_get: expected self._ls_from_http.__self__ id = {id(self._ls_from_http.__self__) if hasattr(self._ls_from_http, '__self__') else 'N/A'}")
+        trace(logger, "_get token after generation=%s", format_token_for_log(self.token))
+        trace(logger, "_get expanding path")
 
         # Now perform the actual _get logic with directory filtering
         if isinstance(lpath, list) and isinstance(rpath, list):

--- a/src/pelicanfs/log_utils.py
+++ b/src/pelicanfs/log_utils.py
@@ -1,0 +1,41 @@
+"""
+Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License.  You may
+obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Optional, Union
+
+# Finer than DEBUG for internal call-flow tracing (not enabled by default).
+TRACE = 5
+logging.addLevelName(TRACE, "TRACE")
+
+
+def trace(logger: logging.Logger, msg: str, *args, **kwargs) -> None:
+    if logger.isEnabledFor(TRACE):
+        logger._log(TRACE, msg, args, **kwargs)
+
+
+def format_token_for_log(token: Optional[Union[str, bytes]]) -> Optional[str]:
+    """Return JWT header and payload (no signature) for safe, readable logging."""
+    if not token:
+        return None
+    if isinstance(token, bytes):
+        raw = token.decode("utf-8", errors="replace")
+    else:
+        raw = token
+    raw = raw.removeprefix("Bearer ").strip()
+    parts = raw.split(".")
+    if len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}"
+    return raw

--- a/src/pelicanfs/token_content_iterator.py
+++ b/src/pelicanfs/token_content_iterator.py
@@ -288,22 +288,26 @@ class TokenContentIterator:
                     if child.before:
                         before_text = child.before if isinstance(child.before, str) else child.before.decode("utf-8", errors="replace")
                         output_lines.append(before_text)
-                        # Only display non-JSON debug output to the user
-                        # JSON debug output (containing braces) is logged but not printed
-                        filtered = re.sub(jwt_pattern, "[TOKEN_REDACTED]", before_text)
-                        if filtered.strip() and "{" not in filtered and "}" not in filtered:
-                            print(filtered, end="")
+                        # Filter line-by-line: skip JSON debug lines (containing braces)
+                        # but still print human-readable lines (e.g. the password prompt
+                        # preamble) even when debug logging produces JSON on other lines.
+                        for line in before_text.splitlines(keepends=True):
+                            filtered_line = re.sub(jwt_pattern, "[TOKEN_REDACTED]", line)
+                            if filtered_line.strip() and "{" not in filtered_line and "}" not in filtered_line:
+                                print(filtered_line, end="", flush=True)
 
                     if index == 0:  # Password prompt
-                        # Get the matched text
+                        # Get the matched text (e.g. "password: ")
                         match_text = child.after if isinstance(child.after, str) else child.after.decode("utf-8", errors="replace")
                         output_lines.append(match_text)
-                        print(match_text, end="")
 
-                        # Use getpass to securely prompt for password
+                        # Print the matched "password:" text and flush before blocking
+                        # on getpass, so the full prompt (before_text + match_text) is
+                        # visible. Pass empty string to getpass so it doesn't double-print.
                         import getpass
 
-                        password = getpass.getpass("")
+                        print(match_text, end="", flush=True)
+                        password = getpass.getpass(prompt="")
                         child.sendline(password)
 
                     elif index == 1:  # URL (device flow)
@@ -317,10 +321,11 @@ class TokenContentIterator:
                         if child.before:
                             before_text = child.before if isinstance(child.before, str) else child.before.decode("utf-8", errors="replace")
                             output_lines.append(before_text)
-                            # Only display non-JSON debug output
-                            filtered = re.sub(jwt_pattern, "[TOKEN_REDACTED]", before_text)
-                            if filtered.strip() and "{" not in filtered and "}" not in filtered:
-                                print(filtered, end="")
+                            # Filter line-by-line to skip JSON debug lines
+                            for line in before_text.splitlines(keepends=True):
+                                filtered_line = re.sub(jwt_pattern, "[TOKEN_REDACTED]", line)
+                                if filtered_line.strip() and "{" not in filtered_line and "}" not in filtered_line:
+                                    print(filtered_line, end="")
                         break
 
                     elif index == 3:  # Timeout

--- a/src/pelicanfs/token_content_iterator.py
+++ b/src/pelicanfs/token_content_iterator.py
@@ -13,16 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import io
 import json
 import logging
 import os
 import platform
 import re
 import shutil
-import subprocess
-import sys
-import time
+import traceback
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import List, Optional
@@ -32,18 +29,32 @@ from igwn_auth_utils.scitokens import (
     default_bearer_token_file,
 )
 
-# Platform-specific imports
+# Platform-specific imports for pexpect
 _IS_WINDOWS = platform.system() == "Windows"
-if not _IS_WINDOWS:
-    import pty
-    import select
+
+# Try to import pexpect (Unix) or wexpect (Windows)
+_PEXPECT_AVAILABLE = False
+_WEXPECT_AVAILABLE = False
+
+if _IS_WINDOWS:
+    try:
+        import wexpect
+
+        _WEXPECT_AVAILABLE = True
+    except ImportError:
+        pass
+else:
+    try:
+        import pexpect
+
+        _PEXPECT_AVAILABLE = True
+    except ImportError:
+        pass
 
 logger = logging.getLogger("fsspec.pelican")
 
 # Default constants for OIDC device flow (can be overridden)
 DEFAULT_OIDC_TIMEOUT_SECONDS = 300  # 5 minutes
-DEFAULT_PTY_BUFFER_SIZE = 1024
-DEFAULT_SELECT_TIMEOUT = 0.1  # 100ms for responsive I/O
 
 
 def get_token_from_file(token_location: str) -> str:
@@ -110,11 +121,9 @@ class TokenContentIterator:
         destination_url (str): Destination URL for the token request.
         pelican_url (str): Pelican protocol URL (pelican://<federation-url>/<path>) for OIDC device flow.
         oidc_timeout_seconds (int): Timeout in seconds for OIDC device flow (default: 300).
-        pty_buffer_size (int): Buffer size for PTY I/O (default: 1024).
-        select_timeout (float): Timeout in seconds for select() calls (default: 0.1).
         method_index (int): Internal index of the current discovery method.
         cred_locations (List[str]): Token file paths discovered via HTCondor fallback.
-        index (int): Internal index of the current fallback cred_location
+        fallback_index (int): Internal index of the current fallback cred_location
     """
 
     location: str
@@ -123,8 +132,6 @@ class TokenContentIterator:
     destination_url: Optional[str] = None
     pelican_url: Optional[str] = None
     oidc_timeout_seconds: int = DEFAULT_OIDC_TIMEOUT_SECONDS
-    pty_buffer_size: int = DEFAULT_PTY_BUFFER_SIZE
-    select_timeout: float = DEFAULT_SELECT_TIMEOUT
     method_index: int = 0
     cred_locations: List[str] = field(default_factory=list)
     fallback_index: int = 0
@@ -167,220 +174,176 @@ class TokenContentIterator:
 
         return flags
 
+    def _is_oidc_device_flow_url(self, url: str) -> bool:
+        """
+        Check if a URL is an OIDC device flow authentication URL that users need to visit.
+
+        OIDC device flow URLs typically contain paths like /device, /activate, or similar.
+        URLs embedded in JSON debug output (containing braces, quotes) should not be treated
+        as user-facing authentication URLs.
+
+        Args:
+            url: The URL to check
+
+        Returns:
+            bool: True if this appears to be an OIDC device flow URL for user authentication
+        """
+        # If the URL contains JSON-like characters, it's probably embedded in debug output
+        if "{" in url or "}" in url or '"' in url or ':{"' in url:
+            return False
+
+        # OIDC device flow URLs typically have these path patterns
+        oidc_patterns = ["/device", "/activate", "/oauth", "/authorize", "/login"]
+        url_lower = url.lower()
+        return any(pattern in url_lower for pattern in oidc_patterns)
+
+    def _display_url_for_user(self, url: str) -> None:
+        """
+        Display a URL to the user, making it clickable in Jupyter environments.
+
+        Only creates clickable links for actual OIDC device flow URLs that users
+        need to visit. URLs embedded in debug JSON output are not made clickable.
+
+        Args:
+            url: The URL to potentially display as clickable
+        """
+        # Only create clickable links for actual OIDC device flow URLs
+        if not self._is_oidc_device_flow_url(url):
+            # This is likely a URL embedded in debug output - just print it normally
+            # without creating a clickable link
+            return
+
+        # Filter out tokens
+        jwt_pattern = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+        filtered_url = re.sub(jwt_pattern, "[TOKEN_REDACTED]", url)
+
+        # Try to make URLs clickable in Jupyter/IPython
+        try:
+            from IPython.display import HTML, display
+
+            display(HTML(f'<a href="{filtered_url}" target="_blank">Click here to authenticate: {filtered_url}</a>'))
+        except ImportError:
+            pass
+
+        # Always print the text version
+        print(f"Please visit: {filtered_url}")
+
     def _get_token_from_pelican_binary(self) -> Optional[str]:
         """
         Invoke pelican binary to get token via OIDC device flow.
 
-        Uses platform-specific approach for secure password input:
-        - Unix: pty module with stdin from /dev/tty
-        - Windows: subprocess with inherited stdin
+        Uses pexpect (Unix) or wexpect (Windows) to interact with the pelican
+        binary in a pseudo-terminal. This allows proper handling of password
+        prompts and interactive OIDC device flow regardless of the environment
+        (terminal, Jupyter, IDE, etc.).
 
         Returns:
             str: JWT token if successful, None otherwise
         """
-
         if not self.pelican_url:
             logger.warning("Cannot invoke pelican binary without pelican URL")
             return None
 
-        flags = self._get_pelican_flag()
-        cmd = ["pelican"] + ["token", "fetch", self.pelican_url] + flags
+        # Check if pexpect/wexpect is available
+        if _IS_WINDOWS:
+            if not _WEXPECT_AVAILABLE:
+                logger.warning("wexpect is required for OIDC device flow on Windows. " "Install it with: pip install wexpect")
+                return None
+        else:
+            if not _PEXPECT_AVAILABLE:
+                logger.warning("pexpect is required for OIDC device flow. " "Install it with: pip install pexpect")
+                return None
 
-        logger.info(f"Invoking OIDC device flow via pelican binary: {' '.join(cmd)}")
+        flags = self._get_pelican_flag()
+        cmd_str = f"pelican token fetch {self.pelican_url} {' '.join(flags)}"
+
+        logger.info(f"Invoking OIDC device flow via pelican binary: {cmd_str}")
 
         try:
-            # Run the pelican binary with a PTY (pseudo-terminal) to allow interactive OIDC device flow
-            # This lets the user see prompts and interact while we capture the output
-
-            output_data = []
-            start_time = time.time()
-
-            # Platform-specific PTY setup
+            # Use pexpect/wexpect to spawn the process with a PTY
             if _IS_WINDOWS:
-                # Windows: Let the process inherit stdin from the console for password prompts
-                # We use PIPE for stdout/stderr to capture output, but inherit stdin
-                # This allows the pelican binary to handle password prompts directly
-                process = subprocess.Popen(
-                    cmd,
-                    stdin=None,  # Inherit stdin from parent process
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,  # Merge stderr into stdout
-                    text=False,
-                    bufsize=0,  # Unbuffered for real-time output
-                )
-
-                def read_from_pty():
-                    """Read available data from subprocess stdout"""
-                    try:
-                        # Non-blocking read with timeout
-                        import msvcrt
-
-                        if msvcrt.kbhit() or process.stdout:
-                            return process.stdout.read(self.pty_buffer_size)
-                        return b""
-                    except Exception:
-                        return b""
-
-                def write_to_pty(data):
-                    """Not used on Windows with inherited stdin"""
-                    pass
-
-                def is_alive():
-                    """Check if process is still running"""
-                    return process.poll() is None
-
-                stdin_data_to_send = None
+                child = wexpect.spawn(cmd_str, timeout=self.oidc_timeout_seconds)
             else:
-                # Unix: use pty module
-                import termios
+                child = pexpect.spawn(cmd_str, timeout=self.oidc_timeout_seconds, encoding="utf-8")
 
-                master_fd, slave_fd = pty.openpty()
+            output_lines = []
+            jwt_pattern = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
 
-                # Try to open /dev/tty for stdin so password prompts work correctly
-                # If /dev/tty is not available, fall back to slave_fd
+            # Patterns to expect from pelican binary
+            # The order matters - check for password prompt, OIDC URLs, EOF, and timeout
+            # Use a more specific pattern for OIDC device flow URLs to avoid matching
+            # URLs in debug JSON output
+            patterns = [
+                r"[Pp]assword[:\s]*",  # Password prompt (case-insensitive)
+                r'https?://[^\s"}\]]+/(?:device|activate|oauth|authorize|login)[^\s"}\]]*',  # OIDC device flow URL
+                pexpect.EOF if not _IS_WINDOWS else wexpect.EOF,
+                pexpect.TIMEOUT if not _IS_WINDOWS else wexpect.TIMEOUT,
+            ]
+
+            while True:
                 try:
-                    tty_fd = os.open("/dev/tty", os.O_RDWR)
-                    process = subprocess.Popen(cmd, stdin=tty_fd, stdout=slave_fd, stderr=slave_fd, text=False)
-                    os.close(tty_fd)
-                except (OSError, FileNotFoundError):
-                    # /dev/tty not available (e.g., Jupyter with redirected stdin)
-                    # Disable echo on both master and slave PTY to prevent password echo
-                    # This only affects the fallback case where stdin goes through the PTY
-                    try:
-                        # Disable echo on slave side
-                        attrs = termios.tcgetattr(slave_fd)
-                        attrs[3] = attrs[3] & ~termios.ECHO  # Disable ECHO flag
-                        termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+                    index = child.expect(patterns)
 
-                        # Also disable echo on master side
-                        attrs = termios.tcgetattr(master_fd)
-                        attrs[3] = attrs[3] & ~termios.ECHO  # Disable ECHO flag
-                        termios.tcsetattr(master_fd, termios.TCSANOW, attrs)
-                    except Exception as e:
-                        logger.debug(f"Could not disable echo on PTY: {e}")
+                    # Capture any output before the match
+                    if child.before:
+                        before_text = child.before if isinstance(child.before, str) else child.before.decode("utf-8", errors="replace")
+                        output_lines.append(before_text)
+                        # Only display non-JSON debug output to the user
+                        # JSON debug output (containing braces) is logged but not printed
+                        filtered = re.sub(jwt_pattern, "[TOKEN_REDACTED]", before_text)
+                        if filtered.strip() and "{" not in filtered and "}" not in filtered:
+                            print(filtered, end="")
 
-                    process = subprocess.Popen(cmd, stdin=slave_fd, stdout=slave_fd, stderr=slave_fd, text=False)
-                os.close(slave_fd)
+                    if index == 0:  # Password prompt
+                        # Get the matched text
+                        match_text = child.after if isinstance(child.after, str) else child.after.decode("utf-8", errors="replace")
+                        output_lines.append(match_text)
+                        print(match_text, end="")
 
-                def read_from_pty():
-                    """Read available data from Unix PTY"""
-                    ready, _, _ = select.select([master_fd], [], [], self.select_timeout)
-                    if ready:
-                        try:
-                            return os.read(master_fd, self.pty_buffer_size)
-                        except OSError:
-                            return b""
-                    return b""
+                        # Use getpass to securely prompt for password
+                        import getpass
 
-                def write_to_pty(data):
-                    """Write data to Unix PTY"""
-                    os.write(master_fd, data)
+                        password = getpass.getpass("")
+                        child.sendline(password)
 
-                def is_alive():
-                    """Check if process is still running"""
-                    return process.poll() is None
+                    elif index == 1:  # URL (device flow)
+                        # Get the URL
+                        url = child.after if isinstance(child.after, str) else child.after.decode("utf-8", errors="replace")
+                        output_lines.append(url)
+                        self._display_url_for_user(url)
 
-                # Check if stdin has been redirected (e.g., StringIO in Jupyter)
-                # If /dev/tty is available, the process reads from the terminal directly
-                # If not, we need to forward any redirected stdin data
-                stdin_data_to_send = None
-                try:
-                    stdin_fd = sys.stdin.fileno()
-                    # Check if stdin is redirected (not a terminal)
-                    if not os.isatty(stdin_fd):
-                        # Stdin is redirected, read the data to forward it
-                        try:
-                            stdin_data_to_send = sys.stdin.read()
-                            if stdin_data_to_send:
-                                logger.debug(f"Read {len(stdin_data_to_send)} chars from redirected stdin")
-                        except Exception as e:
-                            logger.debug(f"Could not read from redirected stdin: {e}")
-                            stdin_data_to_send = None
-                except (AttributeError, io.UnsupportedOperation):
-                    # stdin doesn't have fileno() - likely redirected (e.g., Jupyter)
-                    try:
-                        stdin_data_to_send = sys.stdin.read()
-                        if stdin_data_to_send:
-                            logger.debug(f"Read {len(stdin_data_to_send)} chars from redirected stdin")
-                    except Exception as e:
-                        logger.debug(f"Could not read from redirected stdin: {e}")
-                        stdin_data_to_send = None
-
-            def read_and_echo_output():
-                """Helper to read from PTY, echo to terminal (filtering sensitive data), and store data"""
-                data = read_from_pty()
-                if data:
-                    # Store raw data for token extraction
-                    output_data.append(data)
-
-                    # Filter sensitive information before echoing to terminal
-                    decoded_data = data.decode("utf-8", errors="replace")
-
-                    # Hide passwords and tokens using regex patterns
-                    # Pattern for JWT tokens
-                    jwt_pattern = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
-                    filtered_data = re.sub(jwt_pattern, "[TOKEN_REDACTED]", decoded_data)
-
-                    # Try to write to stdout.buffer (for real terminals)
-                    # Fall back to stdout.write() for Jupyter/IPython environments
-                    try:
-                        sys.stdout.buffer.write(filtered_data.encode("utf-8"))
-                        sys.stdout.buffer.flush()
-                    except AttributeError:
-                        # stdout doesn't have buffer (e.g., Jupyter/IPython)
-                        sys.stdout.write(filtered_data)
-                        sys.stdout.flush()
-                return data
-
-            # Read from PTY and echo to terminal, also forward stdin to the process
-            try:
-                while True:
-                    # Check timeout
-                    if time.time() - start_time > self.oidc_timeout_seconds:
-                        process.kill()
-                        logger.warning(f"Pelican binary timed out (exceeded {self.oidc_timeout_seconds} seconds)")
-                        return None
-
-                    # Check if process is still running
-                    if not is_alive():
-                        # Process finished, read any remaining output
-                        while True:
-                            data = read_from_pty()
-                            if not data:
-                                break
+                    elif index == 2:  # EOF - process finished
+                        # Capture any remaining output
+                        if child.before:
+                            before_text = child.before if isinstance(child.before, str) else child.before.decode("utf-8", errors="replace")
+                            output_lines.append(before_text)
+                            # Only display non-JSON debug output
+                            filtered = re.sub(jwt_pattern, "[TOKEN_REDACTED]", before_text)
+                            if filtered.strip() and "{" not in filtered and "}" not in filtered:
+                                print(filtered, end="")
                         break
 
-                    # Read subprocess output
-                    read_and_echo_output()
+                    elif index == 3:  # Timeout
+                        logger.warning(f"Pelican binary timed out (exceeded {self.oidc_timeout_seconds} seconds)")
+                        child.close(force=True)
+                        return None
 
-                    # Handle stdin forwarding (Unix only - Windows uses simpler approach)
-                    # Note: When /dev/tty is available, pelican reads stdin directly from the terminal
-                    # This code only applies when stdin is redirected (e.g., Jupyter notebooks)
-                    if not _IS_WINDOWS:
-                        if stdin_data_to_send:
-                            # Redirected stdin - send buffered data once
-                            try:
-                                write_to_pty(stdin_data_to_send.encode("utf-8"))
-                                stdin_data_to_send = None  # Only send once
-                            except OSError as e:
-                                logger.debug(f"Error writing redirected stdin to PTY: {e}")
-            finally:
-                # Cleanup platform-specific resources
-                if not _IS_WINDOWS:
-                    # Unix cleanup
-                    os.close(master_fd)
+                except (pexpect.EOF if not _IS_WINDOWS else wexpect.EOF):
+                    break
+                except (pexpect.TIMEOUT if not _IS_WINDOWS else wexpect.TIMEOUT):
+                    logger.warning(f"Pelican binary timed out (exceeded {self.oidc_timeout_seconds} seconds)")
+                    child.close(force=True)
+                    return None
 
-            # Wait for process to finish and get return code
-            process.wait()
-            returncode = process.returncode
+            child.close()
 
-            if returncode != 0:
-                logger.debug(f"Pelican binary exited with code {returncode}")
+            # Check exit status
+            if child.exitstatus != 0:
+                logger.debug(f"Pelican binary exited with code {child.exitstatus}")
                 return None
 
             # Extract JWT token from captured output
-            full_output = b"".join(output_data).decode("utf-8", errors="replace")
-            jwt_pattern = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+            full_output = "".join(output_lines)
             matches = re.findall(jwt_pattern, full_output)
 
             if matches:
@@ -389,13 +352,11 @@ class TokenContentIterator:
                 return token
             else:
                 logger.warning("Could not extract JWT token from pelican binary output")
-                logger.debug(f"Output was: {full_output}")
+                logger.debug(f"Output was: {re.sub(jwt_pattern, '[TOKEN_REDACTED]', full_output)}")
                 return None
 
         except Exception as err:
             logger.debug(f"Error invoking pelican binary: {err}")
-            import traceback
-
             logger.debug(traceback.format_exc())
             return None
 

--- a/src/pelicanfs/token_content_iterator.py
+++ b/src/pelicanfs/token_content_iterator.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import html
 import json
 import logging
 import os
@@ -29,32 +30,39 @@ from igwn_auth_utils.scitokens import (
     default_bearer_token_file,
 )
 
-# Platform-specific imports for pexpect
+from pelicanfs.log_utils import format_token_for_log
+
+# Platform-specific pexpect/wexpect (PTY interaction for OIDC device flow)
 _IS_WINDOWS = platform.system() == "Windows"
 
-# Try to import pexpect (Unix) or wexpect (Windows)
-_PEXPECT_AVAILABLE = False
-_WEXPECT_AVAILABLE = False
+_expect_module = None
 
 if _IS_WINDOWS:
     try:
         import wexpect
 
-        _WEXPECT_AVAILABLE = True
+        _expect_module = wexpect
     except ImportError:
         pass
 else:
     try:
         import pexpect
 
-        _PEXPECT_AVAILABLE = True
+        _expect_module = pexpect
     except ImportError:
         pass
+
+_EOF = _expect_module.EOF if _expect_module is not None else None
+_TIMEOUT = _expect_module.TIMEOUT if _expect_module is not None else None
 
 logger = logging.getLogger("fsspec.pelican")
 
 # Default constants for OIDC device flow (can be overridden)
 DEFAULT_OIDC_TIMEOUT_SECONDS = 300  # 5 minutes
+
+# Match a line-ending password prompt (e.g. "...configuration file:"), not prose such as
+# "asked for this password whenever" (pelican 7.23+ prints several "password" mentions).
+_PASSWORD_PROMPT_PATTERN = r"[Pp]assword[^:\n]*:\s*"
 
 
 def get_token_from_file(token_location: str) -> str:
@@ -221,7 +229,7 @@ class TokenContentIterator:
         try:
             from IPython.display import HTML, display
 
-            display(HTML(f'<a href="{filtered_url}" target="_blank">Click here to authenticate: {filtered_url}</a>'))
+            display(HTML(f'<a href="{html.escape(filtered_url, quote=True)}" target="_blank">' f"Click here to authenticate: {html.escape(filtered_url)}</a>"))
         except ImportError:
             pass
 
@@ -244,15 +252,10 @@ class TokenContentIterator:
             logger.warning("Cannot invoke pelican binary without pelican URL")
             return None
 
-        # Check if pexpect/wexpect is available
-        if _IS_WINDOWS:
-            if not _WEXPECT_AVAILABLE:
-                logger.warning("wexpect is required for OIDC device flow on Windows. " "Install it with: pip install wexpect")
-                return None
-        else:
-            if not _PEXPECT_AVAILABLE:
-                logger.warning("pexpect is required for OIDC device flow. " "Install it with: pip install pexpect")
-                return None
+        if _expect_module is None:
+            package = "wexpect" if _IS_WINDOWS else "pexpect"
+            logger.warning(f"{package} is required for OIDC device flow" + (" on Windows" if _IS_WINDOWS else "") + f". Install it with: pip install {package}")
+            return None
 
         flags = self._get_pelican_flag()
         cmd_str = f"pelican token fetch {self.pelican_url} {' '.join(flags)}"
@@ -260,11 +263,11 @@ class TokenContentIterator:
         logger.info(f"Invoking OIDC device flow via pelican binary: {cmd_str}")
 
         try:
-            # Use pexpect/wexpect to spawn the process with a PTY
+            # Spawn with a PTY; encoding= is pexpect-only (wexpect uses bytes)
             if _IS_WINDOWS:
-                child = wexpect.spawn(cmd_str, timeout=self.oidc_timeout_seconds)
+                child = _expect_module.spawn(cmd_str, timeout=self.oidc_timeout_seconds, echo=False)
             else:
-                child = pexpect.spawn(cmd_str, timeout=self.oidc_timeout_seconds, encoding="utf-8")
+                child = _expect_module.spawn(cmd_str, timeout=self.oidc_timeout_seconds, encoding="utf-8", echo=False)
 
             output_lines = []
             jwt_pattern = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
@@ -274,10 +277,10 @@ class TokenContentIterator:
             # Use a more specific pattern for OIDC device flow URLs to avoid matching
             # URLs in debug JSON output
             patterns = [
-                r"[Pp]assword[:\s]*",  # Password prompt (case-insensitive)
+                _PASSWORD_PROMPT_PATTERN,
                 r'https?://[^\s"}\]]+/(?:device|activate|oauth|authorize|login)[^\s"}\]]*',  # OIDC device flow URL
-                pexpect.EOF if not _IS_WINDOWS else wexpect.EOF,
-                pexpect.TIMEOUT if not _IS_WINDOWS else wexpect.TIMEOUT,
+                _EOF,
+                _TIMEOUT,
             ]
 
             while True:
@@ -309,6 +312,7 @@ class TokenContentIterator:
                         print(match_text, end="", flush=True)
                         password = getpass.getpass(prompt="")
                         child.sendline(password)
+                        del password
 
                     elif index == 1:  # URL (device flow)
                         # Get the URL
@@ -333,9 +337,9 @@ class TokenContentIterator:
                         child.close(force=True)
                         return None
 
-                except (pexpect.EOF if not _IS_WINDOWS else wexpect.EOF):
+                except _EOF:
                     break
-                except (pexpect.TIMEOUT if not _IS_WINDOWS else wexpect.TIMEOUT):
+                except _TIMEOUT:
                     logger.warning(f"Pelican binary timed out (exceeded {self.oidc_timeout_seconds} seconds)")
                     child.close(force=True)
                     return None
@@ -437,7 +441,7 @@ class TokenContentIterator:
                         logger.debug(f"Using token from default bearer token file: {token_file}")
                         try:
                             token = get_token_from_file(token_file)
-                            logger.debug(f"Successfully read token from default file: {token[:30] if token else 'None'}...")
+                            logger.debug("Successfully read token from default file: %s", format_token_for_log(token))
                             return token
                         except Exception as err:
                             logger.warning(f"Could not read default bearer token: {err}")

--- a/src/pelicanfs/token_generator.py
+++ b/src/pelicanfs/token_generator.py
@@ -71,8 +71,6 @@ class TokenGenerator:
         token_name: Optional[str] = None,
         pelican_url: Optional[str] = None,
         oidc_timeout_seconds: int = 300,
-        pty_buffer_size: int = 1024,
-        select_timeout: float = 0.1,
     ) -> None:
         self.DirResp: object = dir_resp
         self.DestinationURL: str = destination_url
@@ -85,8 +83,6 @@ class TokenGenerator:
         self._lock: threading.Lock = threading.Lock()
         # OIDC device flow configuration
         self.oidc_timeout_seconds: int = oidc_timeout_seconds
-        self.pty_buffer_size: int = pty_buffer_size
-        self.select_timeout: float = select_timeout
 
     def set_token_location(self, token_location: str) -> None:
         """Sets the location (e.g., file path) where tokens can be found."""
@@ -139,8 +135,6 @@ class TokenGenerator:
                     destination_url=self.DestinationURL,
                     pelican_url=self.PelicanURL,
                     oidc_timeout_seconds=self.oidc_timeout_seconds,
-                    pty_buffer_size=self.pty_buffer_size,
-                    select_timeout=self.select_timeout,
                 )
 
             logger.debug("About to enter token validation loop")

--- a/src/pelicanfs/token_generator.py
+++ b/src/pelicanfs/token_generator.py
@@ -28,6 +28,7 @@ from pelicanfs.exceptions import (
     NoCredentialsException,
     TokenIteratorException,
 )
+from pelicanfs.log_utils import format_token_for_log, trace
 from pelicanfs.token_content_iterator import TokenContentIterator
 
 logger = logging.getLogger("fsspec.pelican")
@@ -137,24 +138,21 @@ class TokenGenerator:
                     oidc_timeout_seconds=self.oidc_timeout_seconds,
                 )
 
-            logger.debug("About to enter token validation loop")
-            logger.debug(f"self.Iterator at validation loop: {self.Iterator}")
+            trace(logger, "entering token validation loop")
             try:
                 # Use next() to get tokens one at a time from the iterator
                 while True:
                     try:
                         contents = next(self.Iterator)
-                        # Check if the token is valid and acceptable
-                        logger.debug(f"Validating token for operation: {operation}")
                         valid, expiry = token_is_valid_and_acceptable(contents, object_path, self.DirResp, operation)
-                        logger.debug(f"Token validation result: valid={valid}, expiry={expiry}")
+                        trace(logger, "token validation valid=%s expiry=%s jwt=%s", valid, expiry, format_token_for_log(contents))
                         if valid:
                             self.token = TokenInfo(contents, expiry)
                             return contents
                         elif contents and expiry > datetime.now(timezone.utc):
                             potential_tokens.append(TokenInfo(contents, expiry))
                     except StopIteration:
-                        logger.debug("Token iterator reached StopIteration")
+                        trace(logger, "token iterator exhausted")
                         break
             except Exception as e:
                 logger.error(f"Error iterating tokens: {e}")
@@ -211,35 +209,32 @@ def token_is_valid_and_acceptable(
     Returns:
         Tuple (is_valid, expiry_datetime)
     """
-    logger.debug(f"token_is_valid_and_acceptable called with operation: {operation}")
+    trace(logger, "token_is_valid_and_acceptable operation=%s", operation)
 
     try:
         # Try to deserialize the token without SSL verification
         # The SSL issue is likely happening when SciToken tries to fetch the public key
         token: SciToken = SciToken.deserialize(jwt_serialized)
-        logger.debug("Successfully deserialized token")
     except (ValueError, Exception) as e:
-        logger.debug(f"Failed to deserialize token: {jwt_serialized[:30]}... Error: {e}")
+        trace(logger, "failed to deserialize token jwt=%s: %s", format_token_for_log(jwt_serialized), e)
         return False, datetime.fromtimestamp(0, tz=timezone.utc)
 
     # Check if the token is expired
     exp = token.get("exp")
     if exp is None:
-        logger.debug("Token missing exp claim")
+        trace(logger, "token missing exp claim jwt=%s", format_token_for_log(jwt_serialized))
         return False, datetime.fromtimestamp(0, tz=timezone.utc)
 
     expiry_dt: datetime = datetime.fromtimestamp(exp, tz=timezone.utc)
-    logger.debug(f"Token expiry: {expiry_dt}")
     if expiry_dt <= datetime.now(timezone.utc):
-        logger.debug(f"Token expired at {expiry_dt}")
+        trace(logger, "token expired at %s jwt=%s", expiry_dt, format_token_for_log(jwt_serialized))
         return False, expiry_dt
 
     # Get the allowed issuers from the director response and check if the token issuer is in the list
     issuers: List[str] = []
     if dir_resp and hasattr(dir_resp, "x_pel_tok_gen_hdr") and dir_resp.x_pel_tok_gen_hdr:
         issuers = dir_resp.x_pel_tok_gen_hdr.issuers or []
-    logger.debug(f"Allowed issuers: {issuers}")
-    logger.debug(f"Token issuer: {dict(token._verified_claims).get('iss')}")
+    trace(logger, "allowed issuers=%s token issuer=%s", issuers, dict(token._verified_claims).get("iss"))
 
     # Get the operation type and set the required scopes
     if operation in [TokenOperation.TokenWrite, TokenOperation.TokenSharedWrite]:
@@ -249,8 +244,7 @@ def token_is_valid_and_acceptable(
     else:
         ok_scopes = []
 
-    logger.debug(f"Required scopes for operation '{operation}': {ok_scopes}")
-    logger.debug(f"Token scopes: {token.get('scope')}")
+    trace(logger, "required scopes=%s token scopes=%s", ok_scopes, token.get("scope"))
 
     token_scopes = token.get("scope", "")
     scope_list = token_scopes.split()
@@ -285,7 +279,7 @@ def token_is_valid_and_acceptable(
             break
 
     if not acceptable_scope:
-        logger.debug("No acceptable scope found in token")
+        trace(logger, "no acceptable scope in token jwt=%s", format_token_for_log(jwt_serialized))
         return False, expiry_dt
 
     return True, expiry_dt

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -78,3 +78,73 @@ def test_authz_query(httpserver: HTTPServer, get_client):
     )
 
     assert pelfs.cat("/foo/bar?authz=test") == b"hello, world!"
+
+
+def test_token_set_in_http_filesystem_kwargs(httpserver: HTTPServer, get_client):
+    """
+    Test that tokens passed via headers are set in http_file_system.kwargs.
+
+    Regression test: Ensures that when HTTPFileSystem makes requests, it includes
+    the Authorization header. Previously tokens were not properly propagated to
+    http_file_system.kwargs, causing 403 errors.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    test_token = "Bearer test_token_123"
+    pelfs = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+        headers={"Authorization": test_token},
+    )
+
+    # Token should be set in self.token
+    assert pelfs.token == test_token
+
+    # Token should also be in http_file_system.kwargs for requests
+    http_headers = pelfs.http_file_system.kwargs.get("headers", {})
+    assert http_headers.get("Authorization") == test_token
+
+
+def test_set_http_filesystem_token_updates_kwargs(httpserver: HTTPServer, get_client):
+    """
+    Test that _set_http_filesystem_token properly updates http_file_system.kwargs.
+
+    Regression test: This method is called after token generation to ensure tokens
+    are included in subsequent HTTP requests.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    pelfs = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+    )
+
+    # Initially no token
+    assert pelfs.http_file_system.kwargs.get("headers", {}).get("Authorization") is None
+
+    # Set a token
+    pelfs._set_http_filesystem_token("new_token_456")
+
+    # Token should now be in http_file_system.kwargs
+    http_headers = pelfs.http_file_system.kwargs.get("headers", {})
+    assert http_headers.get("Authorization") == "Bearer new_token_456"
+
+
+def test_get_token_returns_token_without_bearer_prefix(httpserver: HTTPServer, get_client):
+    """
+    Test that _get_token() returns the token value without the Bearer prefix.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    pelfs = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+        headers={"Authorization": "Bearer my_token"},
+    )
+
+    # _get_token should return the raw token value
+    token = pelfs._get_token()
+    assert token == "my_token"

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,110 @@
+"""
+Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License.  You may
+obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for PelicanFileSystem core functionality and initialization.
+"""
+from pytest_httpserver import HTTPServer
+
+import pelicanfs.core
+
+
+def test_multiple_pelfs_instances_have_separate_http_filesystems(httpserver: HTTPServer, get_client):
+    """
+    Test that creating multiple PelicanFileSystem instances results in
+    separate HTTPFileSystem instances, not shared cached ones.
+
+    Regression test for HTTPFileSystem caching bug: Without skip_instance_cache=True,
+    multiple PelicanFileSystem instances would share the same HTTPFileSystem,
+    causing method binding issues where tokens set in one instance weren't
+    available in another.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    pelfs1 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+    )
+
+    pelfs2 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+    )
+
+    # Each PelicanFileSystem should have its own HTTPFileSystem instance
+    assert pelfs1.http_file_system is not pelfs2.http_file_system, "Multiple PelicanFileSystem instances should not share HTTPFileSystem instances"
+
+
+def test_ls_method_binding_isolated_between_instances(httpserver: HTTPServer, get_client):
+    """
+    Test that _ls_from_http method binding is isolated between PelicanFileSystem instances.
+
+    Regression test: Without the fix, calling pelfs2._ls_from_http could inadvertently
+    use pelfs1's state because they shared the same HTTPFileSystem.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    pelfs1 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+    )
+
+    pelfs2 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+    )
+
+    # The _ls method on each http_file_system should be bound to its respective PelicanFileSystem
+    assert pelfs1.http_file_system._ls.__self__ is pelfs1, "pelfs1.http_file_system._ls should be bound to pelfs1"
+    assert pelfs2.http_file_system._ls.__self__ is pelfs2, "pelfs2.http_file_system._ls should be bound to pelfs2"
+
+
+def test_token_state_isolated_between_instances(httpserver: HTTPServer, get_client):
+    """
+    Test that token state is isolated between PelicanFileSystem instances.
+
+    Regression test: Without the fix, setting a token on pelfs1 could be
+    overwritten or lost when pelfs2 was created because they shared the
+    same HTTPFileSystem.
+    """
+    httpserver.expect_request("/.well-known/pelican-configuration").respond_with_json({"director_endpoint": httpserver.url_for("/")})
+
+    pelfs1 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+        headers={"Authorization": "Bearer token1"},
+    )
+
+    pelfs2 = pelicanfs.core.PelicanFileSystem(
+        httpserver.url_for("/"),
+        get_client=get_client,
+        skip_instance_cache=True,
+        headers={"Authorization": "Bearer token2"},
+    )
+
+    # Each instance should maintain its own token
+    assert pelfs1.token == "Bearer token1"
+    assert pelfs2.token == "Bearer token2"
+
+    # The HTTPFileSystem kwargs should also be separate
+    pelfs1_auth = pelfs1.http_file_system.kwargs.get("headers", {}).get("Authorization")
+    pelfs2_auth = pelfs2.http_file_system.kwargs.get("headers", {}).get("Authorization")
+
+    assert pelfs1_auth == "Bearer token1"
+    assert pelfs2_auth == "Bearer token2"

--- a/test/test_oidc_jupyter.py
+++ b/test/test_oidc_jupyter.py
@@ -1,0 +1,467 @@
+"""
+Tests for OIDC device flow and Jupyter notebook integration.
+
+These tests mock the pelican binary interaction via pexpect to verify:
+1. Password prompting works correctly
+2. OIDC device flow URLs are displayed (with Jupyter HTML when available)
+3. Token extraction from pelican binary output
+4. Error handling for timeouts and failures
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from scitokens import SciToken
+
+from pelicanfs.token_content_iterator import TokenContentIterator, TokenDiscoveryMethod
+from pelicanfs.token_generator import TokenOperation
+
+
+def generate_test_token(issuer="https://test-issuer.example.com", scopes=None, lifetime=3600):
+    """Generate a valid JWT token for testing.
+
+    Returns a string (decoded from bytes) since that's what the pelican binary outputs.
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+
+    token = SciToken(key=private_pem, algorithm="ES256")
+    token["iss"] = issuer
+    token["aud"] = "https://test.example.com"
+    token["scope"] = " ".join(scopes) if scopes else "storage.read:/"
+
+    # Decode to string since pelican binary outputs text
+    return token.serialize(issuer=issuer, lifetime=lifetime).decode("utf-8")
+
+
+class MockPexpectChild:
+    """Mock pexpect child process for simulating pelican binary interaction."""
+
+    def __init__(self, interactions, exit_status=0):
+        """
+        Args:
+            interactions: List of tuples defining the interaction sequence.
+                Each tuple is (pattern_index, before_text, after_text)
+                where pattern_index maps to:
+                    0 = password prompt
+                    1 = OIDC URL
+                    2 = EOF
+                    3 = TIMEOUT
+            exit_status: The exit status code to return
+        """
+        self.interactions = list(interactions)
+        self.interaction_index = 0
+        self.before = ""
+        self.after = ""
+        self.exitstatus = exit_status
+        self.password_received = None
+        self._closed = False
+
+    def expect(self, patterns):
+        if self.interaction_index >= len(self.interactions):
+            # Simulate EOF when no more interactions
+            raise EOFError("End of interactions")
+
+        interaction = self.interactions[self.interaction_index]
+        self.interaction_index += 1
+
+        pattern_index, before, after = interaction
+        self.before = before
+        self.after = after
+        return pattern_index
+
+    def sendline(self, text):
+        """Capture password input."""
+        self.password_received = text
+
+    def close(self, force=False):
+        self._closed = True
+
+
+class MockEOF(Exception):
+    """Mock EOF exception."""
+
+    pass
+
+
+class MockTIMEOUT(Exception):
+    """Mock TIMEOUT exception."""
+
+    pass
+
+
+@pytest.fixture
+def mock_pexpect():
+    """Create a mock pexpect module."""
+    mock_module = MagicMock()
+    mock_module.EOF = MockEOF
+    mock_module.TIMEOUT = MockTIMEOUT
+    return mock_module
+
+
+@pytest.fixture
+def iterator_factory():
+    """Factory to create TokenContentIterator instances."""
+
+    def factory(pelican_url="pelican://test.example.com/namespace/file.txt", operation=None, oidc_timeout_seconds=300):
+        return TokenContentIterator(location=None, name="test_token", operation=operation, pelican_url=pelican_url, oidc_timeout_seconds=oidc_timeout_seconds)  # Required field
+
+    return factory
+
+
+class TestOIDCDeviceFlow:
+    """Test OIDC device flow via pelican binary."""
+
+    def test_password_prompt_handling(self, mock_pexpect, iterator_factory):
+        """Test that password prompts are handled correctly."""
+        test_token = generate_test_token()
+
+        # Define interaction sequence:
+        # 1. Password prompt appears
+        # 2. After password, token is output and EOF
+        mock_child = MockPexpectChild(
+            [
+                (0, "Connecting to server...\n", "Password: "),  # Password prompt
+                (2, f"\nAuthenticated successfully.\nToken: {test_token}\n", ""),  # EOF with token
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_getpass = MagicMock(return_value="test_password_123")
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    with patch("getpass.getpass", mock_getpass):
+                        iterator = iterator_factory()
+                        # Mock _pelican_binary_exists to return True
+                        iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+                        token = iterator._get_token_from_pelican_binary()
+
+        # Verify password was requested and sent
+        mock_getpass.assert_called_once_with("")
+        assert mock_child.password_received == "test_password_123"
+
+        # Verify token was extracted
+        assert token == test_token
+
+    def test_oidc_url_display_without_jupyter(self, mock_pexpect, iterator_factory, capsys):
+        """Test that OIDC URLs are printed as text when not in Jupyter."""
+        test_token = generate_test_token()
+        oidc_url = "https://auth.example.com/device?code=ABC123"
+
+        mock_child = MockPexpectChild(
+            [
+                (1, "", oidc_url),  # OIDC URL
+                (2, f"\n{test_token}\n", ""),  # EOF with token
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    iterator = iterator_factory()
+                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+                    token = iterator._get_token_from_pelican_binary()
+
+        captured = capsys.readouterr()
+        assert f"Please visit: {oidc_url}" in captured.out
+        assert token == test_token
+
+    def test_timeout_handling(self, mock_pexpect, iterator_factory):
+        """Test that timeouts are handled gracefully."""
+        mock_child = MockPexpectChild(
+            [
+                (3, "Waiting for authentication...", ""),  # TIMEOUT
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    iterator = iterator_factory(oidc_timeout_seconds=5)
+                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+                    token = iterator._get_token_from_pelican_binary()
+
+        assert token is None
+        assert mock_child._closed
+
+    def test_pelican_binary_not_found(self, iterator_factory, caplog):
+        """Test behavior when pelican binary is not installed."""
+        import logging
+
+        iterator = iterator_factory()
+        # Mock _pelican_binary_exists to return False
+        iterator._pelican_binary_exists = MagicMock(return_value=False)
+
+        # Start iteration to trigger OIDC_DEVICE_FLOW method
+        iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(StopIteration):
+                next(iterator)
+
+        assert "pelican" in caplog.text.lower()
+
+    def test_non_zero_exit_status(self, mock_pexpect, iterator_factory):
+        """Test handling of pelican binary returning non-zero exit status."""
+        mock_child = MockPexpectChild(
+            [
+                (2, "Error: Authentication failed\n", ""),  # EOF with error
+            ],
+            exit_status=1,
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    iterator = iterator_factory()
+                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+                    token = iterator._get_token_from_pelican_binary()
+
+        assert token is None
+
+    def test_token_redaction_in_output(self, mock_pexpect, iterator_factory, capsys):
+        """Test that tokens are redacted when displayed to user."""
+        test_token = generate_test_token()
+
+        # Simulate debug output containing token (without JSON braces so it gets printed)
+        debug_output = f"Debug info without braces\nToken received: {test_token}\n"
+
+        mock_child = MockPexpectChild(
+            [
+                (2, debug_output, ""),  # EOF with debug output containing token
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    iterator = iterator_factory()
+                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+                    token = iterator._get_token_from_pelican_binary()
+
+        captured = capsys.readouterr()
+        # Token should be redacted in displayed output
+        assert "[TOKEN_REDACTED]" in captured.out
+        # But the actual token should still be returned
+        assert token == test_token
+
+
+class TestJupyterURLDisplay:
+    """Test the _display_url_for_user method specifically."""
+
+    def test_display_url_for_user_oidc_url(self, iterator_factory, capsys):
+        """Test that OIDC device flow URLs are displayed."""
+        iterator = iterator_factory()
+
+        oidc_url = "https://auth.example.com/device/activate?code=XYZ"
+        iterator._display_url_for_user(oidc_url)
+
+        captured = capsys.readouterr()
+        assert f"Please visit: {oidc_url}" in captured.out
+
+    def test_display_url_for_user_non_oidc_url(self, iterator_factory, capsys):
+        """Test that non-OIDC URLs are not displayed as clickable."""
+        iterator = iterator_factory()
+
+        # A regular URL that's not an OIDC device flow URL
+        regular_url = "https://example.com/some/path"
+        iterator._display_url_for_user(regular_url)
+
+        captured = capsys.readouterr()
+        # Should NOT be displayed
+        assert regular_url not in captured.out
+
+    def test_display_url_redacts_tokens(self, iterator_factory, capsys):
+        """Test that tokens embedded in URLs are redacted."""
+        iterator = iterator_factory()
+
+        test_token = generate_test_token()
+        url_with_token = f"https://auth.example.com/device?token={test_token}"
+        iterator._display_url_for_user(url_with_token)
+
+        captured = capsys.readouterr()
+        # Token should be redacted
+        assert "[TOKEN_REDACTED]" in captured.out
+        assert test_token not in captured.out
+
+    def test_is_oidc_device_flow_url(self, iterator_factory):
+        """Test URL pattern matching for OIDC device flow URLs."""
+        iterator = iterator_factory()
+
+        # Should match OIDC device flow URLs
+        assert iterator._is_oidc_device_flow_url("https://auth.example.com/device")
+        assert iterator._is_oidc_device_flow_url("https://auth.example.com/activate?code=123")
+        assert iterator._is_oidc_device_flow_url("https://auth.example.com/oauth/authorize")
+        assert iterator._is_oidc_device_flow_url("https://auth.example.com/login?redirect=x")
+
+        # Should NOT match regular URLs
+        assert not iterator._is_oidc_device_flow_url("https://example.com/")
+        assert not iterator._is_oidc_device_flow_url("https://example.com/api/data")
+        assert not iterator._is_oidc_device_flow_url("https://cache.example.com/namespace/file.txt")
+
+    def test_jupyter_html_display_called(self, iterator_factory, capsys):
+        """Test that IPython.display.HTML is called in Jupyter environment."""
+        mock_display = MagicMock()
+        mock_html_class = MagicMock(return_value="<html>")
+
+        mock_ipython_display = MagicMock()
+        mock_ipython_display.display = mock_display
+        mock_ipython_display.HTML = mock_html_class
+
+        iterator = iterator_factory()
+
+        oidc_url = "https://auth.example.com/device?code=TEST"
+
+        # Patch IPython.display to be available
+        with patch.dict(sys.modules, {"IPython.display": mock_ipython_display}):
+            iterator._display_url_for_user(oidc_url)
+
+        # Verify HTML was constructed with clickable link
+        mock_html_class.assert_called_once()
+        html_call_arg = mock_html_class.call_args[0][0]
+        assert "href=" in html_call_arg
+        assert oidc_url in html_call_arg
+        assert 'target="_blank"' in html_call_arg
+
+        # Verify display was called
+        mock_display.assert_called_once()
+
+        # Also verify text fallback was printed
+        captured = capsys.readouterr()
+        assert f"Please visit: {oidc_url}" in captured.out
+
+
+class TestPelicanBinaryFlags:
+    """Test pelican binary command construction."""
+
+    def test_get_pelican_flag_read_operation(self, iterator_factory):
+        """Test flags for read operation."""
+        iterator = iterator_factory(operation=TokenOperation.TokenRead)
+
+        flags = iterator._get_pelican_flag()
+
+        assert "-r" in flags
+        assert "-w" not in flags
+
+    def test_get_pelican_flag_write_operation(self, iterator_factory):
+        """Test flags for write operation."""
+        iterator = iterator_factory(operation=TokenOperation.TokenWrite)
+
+        flags = iterator._get_pelican_flag()
+
+        assert "-w" in flags
+        assert "-r" not in flags
+
+    def test_get_pelican_flag_default_operation(self, iterator_factory):
+        """Test flags default to read when operation is None."""
+        iterator = iterator_factory(operation=None)
+
+        flags = iterator._get_pelican_flag()
+
+        assert "-r" in flags
+        assert "-w" not in flags
+
+
+class TestPasswordPromptWithGetpass:
+    """Test password prompting via getpass."""
+
+    def test_getpass_called_on_password_prompt(self, mock_pexpect, iterator_factory):
+        """Verify getpass.getpass is called when password prompt is detected."""
+        test_token = generate_test_token()
+        mock_child = MockPexpectChild(
+            [
+                (0, "", "Password: "),  # Password prompt
+                (2, f"{test_token}\n", ""),  # EOF with token
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        captured_password = []
+
+        def mock_getpass(prompt):
+            captured_password.append(prompt)
+            return "secret123"
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    with patch("getpass.getpass", mock_getpass):
+                        iterator = iterator_factory()
+                        iterator._pelican_binary_exists = MagicMock(return_value=True)
+                        iterator._get_token_from_pelican_binary()
+
+        # getpass should have been called with empty prompt
+        assert captured_password == [""]
+        # Password should have been sent to the child process
+        assert mock_child.password_received == "secret123"
+
+    def test_multiple_password_prompts(self, mock_pexpect, iterator_factory):
+        """Test handling of multiple password prompts (e.g., retry)."""
+        test_token = generate_test_token()
+        mock_child = MockPexpectChild(
+            [
+                (0, "", "Password: "),  # First password prompt
+                (0, "Invalid password\n", "Password: "),  # Second prompt after failure
+                (2, f"Success\n{test_token}\n", ""),  # EOF with token
+            ]
+        )
+
+        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+
+        password_calls = []
+
+        def mock_getpass(prompt):
+            password_calls.append(len(password_calls) + 1)
+            return f"password{len(password_calls)}"
+
+        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                    with patch("getpass.getpass", mock_getpass):
+                        iterator = iterator_factory()
+                        iterator._pelican_binary_exists = MagicMock(return_value=True)
+                        token = iterator._get_token_from_pelican_binary()
+
+        # Should have prompted for password twice
+        assert len(password_calls) == 2
+        assert token == test_token
+
+
+class TestPexpectNotAvailable:
+    """Test behavior when pexpect is not installed."""
+
+    def test_pexpect_not_available_warning(self, iterator_factory, caplog):
+        """Test that appropriate warning is logged when pexpect is not available."""
+        import logging
+
+        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", False):
+            iterator = iterator_factory()
+            iterator._pelican_binary_exists = MagicMock(return_value=True)
+
+            with caplog.at_level(logging.WARNING):
+                token = iterator._get_token_from_pelican_binary()
+
+        assert token is None
+        assert "pexpect" in caplog.text.lower()

--- a/test/test_oidc_jupyter.py
+++ b/test/test_oidc_jupyter.py
@@ -146,7 +146,7 @@ class TestOIDCDeviceFlow:
                         token = iterator._get_token_from_pelican_binary()
 
         # Verify password was requested and sent
-        mock_getpass.assert_called_once_with("")
+        mock_getpass.assert_called_once_with(prompt="")
         assert mock_child.password_received == "test_password_123"
 
         # Verify token was extracted

--- a/test/test_oidc_jupyter.py
+++ b/test/test_oidc_jupyter.py
@@ -7,7 +7,9 @@ These tests mock the pelican binary interaction via pexpect to verify:
 3. Token extraction from pelican binary output
 4. Error handling for timeouts and failures
 """
+import re
 import sys
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +17,11 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from scitokens import SciToken
 
-from pelicanfs.token_content_iterator import TokenContentIterator, TokenDiscoveryMethod
+from pelicanfs.token_content_iterator import (
+    _PASSWORD_PROMPT_PATTERN,
+    TokenContentIterator,
+    TokenDiscoveryMethod,
+)
 from pelicanfs.token_generator import TokenOperation
 
 
@@ -96,9 +102,20 @@ class MockTIMEOUT(Exception):
     pass
 
 
+@contextmanager
+def patch_expect_module(mock_module):
+    """Patch the bound pexpect/wexpect module and exception constants."""
+    with (
+        patch("pelicanfs.token_content_iterator._expect_module", mock_module),
+        patch("pelicanfs.token_content_iterator._EOF", MockEOF),
+        patch("pelicanfs.token_content_iterator._TIMEOUT", MockTIMEOUT),
+    ):
+        yield
+
+
 @pytest.fixture
-def mock_pexpect():
-    """Create a mock pexpect module."""
+def mock_expect_module():
+    """Create a mock pexpect/wexpect module."""
     mock_module = MagicMock()
     mock_module.EOF = MockEOF
     mock_module.TIMEOUT = MockTIMEOUT
@@ -118,7 +135,7 @@ def iterator_factory():
 class TestOIDCDeviceFlow:
     """Test OIDC device flow via pelican binary."""
 
-    def test_password_prompt_handling(self, mock_pexpect, iterator_factory):
+    def test_password_prompt_handling(self, mock_expect_module, iterator_factory):
         """Test that password prompts are handled correctly."""
         test_token = generate_test_token()
 
@@ -132,18 +149,16 @@ class TestOIDCDeviceFlow:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
         mock_getpass = MagicMock(return_value="test_password_123")
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    with patch("getpass.getpass", mock_getpass):
-                        iterator = iterator_factory()
-                        # Mock _pelican_binary_exists to return True
-                        iterator._pelican_binary_exists = MagicMock(return_value=True)
+        with patch_expect_module(mock_expect_module):
+            with patch("getpass.getpass", mock_getpass):
+                iterator = iterator_factory()
+                # Mock _pelican_binary_exists to return True
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
 
-                        token = iterator._get_token_from_pelican_binary()
+                token = iterator._get_token_from_pelican_binary()
 
         # Verify password was requested and sent
         mock_getpass.assert_called_once_with(prompt="")
@@ -152,7 +167,7 @@ class TestOIDCDeviceFlow:
         # Verify token was extracted
         assert token == test_token
 
-    def test_oidc_url_display_without_jupyter(self, mock_pexpect, iterator_factory, capsys):
+    def test_oidc_url_display_without_jupyter(self, mock_expect_module, iterator_factory, capsys):
         """Test that OIDC URLs are printed as text when not in Jupyter."""
         test_token = generate_test_token()
         oidc_url = "https://auth.example.com/device?code=ABC123"
@@ -164,21 +179,19 @@ class TestOIDCDeviceFlow:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    iterator = iterator_factory()
-                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+        with patch_expect_module(mock_expect_module):
+            iterator = iterator_factory()
+            iterator._pelican_binary_exists = MagicMock(return_value=True)
 
-                    token = iterator._get_token_from_pelican_binary()
+            token = iterator._get_token_from_pelican_binary()
 
         captured = capsys.readouterr()
         assert f"Please visit: {oidc_url}" in captured.out
         assert token == test_token
 
-    def test_timeout_handling(self, mock_pexpect, iterator_factory):
+    def test_timeout_handling(self, mock_expect_module, iterator_factory):
         """Test that timeouts are handled gracefully."""
         mock_child = MockPexpectChild(
             [
@@ -186,15 +199,13 @@ class TestOIDCDeviceFlow:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    iterator = iterator_factory(oidc_timeout_seconds=5)
-                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+        with patch_expect_module(mock_expect_module):
+            iterator = iterator_factory(oidc_timeout_seconds=5)
+            iterator._pelican_binary_exists = MagicMock(return_value=True)
 
-                    token = iterator._get_token_from_pelican_binary()
+            token = iterator._get_token_from_pelican_binary()
 
         assert token is None
         assert mock_child._closed
@@ -216,7 +227,7 @@ class TestOIDCDeviceFlow:
 
         assert "pelican" in caplog.text.lower()
 
-    def test_non_zero_exit_status(self, mock_pexpect, iterator_factory):
+    def test_non_zero_exit_status(self, mock_expect_module, iterator_factory):
         """Test handling of pelican binary returning non-zero exit status."""
         mock_child = MockPexpectChild(
             [
@@ -225,19 +236,17 @@ class TestOIDCDeviceFlow:
             exit_status=1,
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    iterator = iterator_factory()
-                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+        with patch_expect_module(mock_expect_module):
+            iterator = iterator_factory()
+            iterator._pelican_binary_exists = MagicMock(return_value=True)
 
-                    token = iterator._get_token_from_pelican_binary()
+            token = iterator._get_token_from_pelican_binary()
 
         assert token is None
 
-    def test_token_redaction_in_output(self, mock_pexpect, iterator_factory, capsys):
+    def test_token_redaction_in_output(self, mock_expect_module, iterator_factory, capsys):
         """Test that tokens are redacted when displayed to user."""
         test_token = generate_test_token()
 
@@ -250,15 +259,13 @@ class TestOIDCDeviceFlow:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    iterator = iterator_factory()
-                    iterator._pelican_binary_exists = MagicMock(return_value=True)
+        with patch_expect_module(mock_expect_module):
+            iterator = iterator_factory()
+            iterator._pelican_binary_exists = MagicMock(return_value=True)
 
-                    token = iterator._get_token_from_pelican_binary()
+            token = iterator._get_token_from_pelican_binary()
 
         captured = capsys.readouterr()
         # Token should be redacted in displayed output
@@ -383,10 +390,55 @@ class TestPelicanBinaryFlags:
         assert "-w" not in flags
 
 
+class TestPasswordPromptPattern:
+    """Unit tests for password prompt detection regex."""
+
+    PELICAN_723_PREAMBLE = (
+        "The client is able to save the authorization in a local file.\n"
+        "This prevents the need to reinitialize the authorization for each transfer.\n"
+        "You will be asked for this password whenever a new session is started.\n"
+        "Please provide a new password to encrypt the local OSDF client configuration file:"
+    )
+
+    def test_does_not_match_prose_password_before_colon_prompt(self):
+        match = re.search(_PASSWORD_PROMPT_PATTERN, self.PELICAN_723_PREAMBLE)
+        assert match is not None
+        assert match.group() == "password to encrypt the local OSDF client configuration file:"
+
+    def test_matches_simple_password_colon_prompt(self):
+        assert re.search(_PASSWORD_PROMPT_PATTERN, "Password: ") is not None
+
+    def test_does_not_match_password_in_warning_without_colon(self):
+        assert re.search(_PASSWORD_PROMPT_PATTERN, "WARNING: empty password provided\n") is None
+
+
 class TestPasswordPromptWithGetpass:
     """Test password prompting via getpass."""
 
-    def test_getpass_called_on_password_prompt(self, mock_pexpect, iterator_factory):
+    def test_pelican_723_preamble_single_getpass(self, mock_expect_module, iterator_factory):
+        """Pelican 7.23+ prose mentions 'password' before the real colon prompt."""
+        test_token = generate_test_token()
+        preamble = TestPasswordPromptPattern.PELICAN_723_PREAMBLE
+        mock_child = MockPexpectChild(
+            [
+                (0, preamble + "\n", ""),
+                (2, f"{test_token}\n", ""),
+            ]
+        )
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
+        mock_getpass = MagicMock(return_value="encrypt_secret")
+
+        with patch_expect_module(mock_expect_module):
+            with patch("getpass.getpass", mock_getpass):
+                iterator = iterator_factory()
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                token = iterator._get_token_from_pelican_binary()
+
+        mock_getpass.assert_called_once_with(prompt="")
+        assert mock_child.password_received == "encrypt_secret"
+        assert token == test_token
+
+    def test_getpass_called_on_password_prompt(self, mock_expect_module, iterator_factory):
         """Verify getpass.getpass is called when password prompt is detected."""
         test_token = generate_test_token()
         mock_child = MockPexpectChild(
@@ -396,7 +448,7 @@ class TestPasswordPromptWithGetpass:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
         captured_password = []
 
@@ -404,20 +456,18 @@ class TestPasswordPromptWithGetpass:
             captured_password.append(prompt)
             return "secret123"
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    with patch("getpass.getpass", mock_getpass):
-                        iterator = iterator_factory()
-                        iterator._pelican_binary_exists = MagicMock(return_value=True)
-                        iterator._get_token_from_pelican_binary()
+        with patch_expect_module(mock_expect_module):
+            with patch("getpass.getpass", mock_getpass):
+                iterator = iterator_factory()
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                iterator._get_token_from_pelican_binary()
 
         # getpass should have been called with empty prompt
         assert captured_password == [""]
         # Password should have been sent to the child process
         assert mock_child.password_received == "secret123"
 
-    def test_multiple_password_prompts(self, mock_pexpect, iterator_factory):
+    def test_multiple_password_prompts(self, mock_expect_module, iterator_factory):
         """Test handling of multiple password prompts (e.g., retry)."""
         test_token = generate_test_token()
         mock_child = MockPexpectChild(
@@ -428,7 +478,7 @@ class TestPasswordPromptWithGetpass:
             ]
         )
 
-        mock_pexpect.spawn = MagicMock(return_value=mock_child)
+        mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
         password_calls = []
 
@@ -436,13 +486,11 @@ class TestPasswordPromptWithGetpass:
             password_calls.append(len(password_calls) + 1)
             return f"password{len(password_calls)}"
 
-        with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-            with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-                with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                    with patch("getpass.getpass", mock_getpass):
-                        iterator = iterator_factory()
-                        iterator._pelican_binary_exists = MagicMock(return_value=True)
-                        token = iterator._get_token_from_pelican_binary()
+        with patch_expect_module(mock_expect_module):
+            with patch("getpass.getpass", mock_getpass):
+                iterator = iterator_factory()
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                token = iterator._get_token_from_pelican_binary()
 
         # Should have prompted for password twice
         assert len(password_calls) == 2
@@ -456,7 +504,7 @@ class TestPexpectNotAvailable:
         """Test that appropriate warning is logged when pexpect is not available."""
         import logging
 
-        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", False):
+        with patch("pelicanfs.token_content_iterator._expect_module", None):
             iterator = iterator_factory()
             iterator._pelican_binary_exists = MagicMock(return_value=True)
 

--- a/test/test_tci.py
+++ b/test/test_tci.py
@@ -14,11 +14,75 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import json
-from unittest.mock import mock_open, patch
+import sys
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from pelicanfs.token_content_iterator import TokenContentIterator, TokenDiscoveryMethod
+
+
+class MockPexpectChild:
+    """Mock pexpect child process for simulating pelican binary interaction."""
+
+    def __init__(self, interactions, exit_status=0):
+        """
+        Args:
+            interactions: List of tuples defining the interaction sequence.
+                Each tuple is (pattern_index, before_text, after_text)
+                where pattern_index maps to:
+                    0 = password prompt
+                    1 = OIDC URL
+                    2 = EOF
+                    3 = TIMEOUT
+            exit_status: The exit status code to return
+        """
+        self.interactions = list(interactions)
+        self.interaction_index = 0
+        self.before = ""
+        self.after = ""
+        self.exitstatus = exit_status
+        self.password_received = None
+        self._closed = False
+
+    def expect(self, patterns):
+        if self.interaction_index >= len(self.interactions):
+            raise EOFError("End of interactions")
+
+        interaction = self.interactions[self.interaction_index]
+        self.interaction_index += 1
+
+        pattern_index, before, after = interaction
+        self.before = before
+        self.after = after
+        return pattern_index
+
+    def sendline(self, text):
+        self.password_received = text
+
+    def close(self, force=False):
+        self._closed = True
+
+
+class MockEOF(Exception):
+    """Mock EOF exception."""
+
+    pass
+
+
+class MockTIMEOUT(Exception):
+    """Mock TIMEOUT exception."""
+
+    pass
+
+
+@pytest.fixture
+def mock_pexpect():
+    """Create a mock pexpect module."""
+    mock_module = MagicMock()
+    mock_module.EOF = MockEOF
+    mock_module.TIMEOUT = MockTIMEOUT
+    return mock_module
 
 
 @pytest.fixture(autouse=True)
@@ -196,151 +260,133 @@ def test_oidc_device_flow_binary_not_found(mock_which, caplog):
     assert any("pelican' binary is installed" in record.message for record in caplog.records)
 
 
-@patch("shutil.which", return_value="/usr/bin/pelican")
-@patch("pty.openpty")
-@patch("subprocess.Popen")
-@patch("os.read")
-@patch("os.write")
-@patch("os.close")
-@patch("select.select")
-def test_oidc_device_flow_successful_token_acquisition(mock_select, mock_close, mock_write, mock_read, mock_popen, mock_openpty, mock_which):
+def test_oidc_device_flow_successful_token_acquisition(mock_pexpect):
     """Test successful token acquisition via OIDC device flow"""
     from pelicanfs.token_generator import TokenOperation
 
     fake_jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
-    # Mock PTY and subprocess
-    mock_openpty.return_value = (100, 101)
-    mock_process = mock_popen.return_value
-    mock_process.returncode = 0
-    mock_process.poll.side_effect = [None, 0]
-
-    # Mock output data
-    full_output = (
-        b"WARNING: empty password provided; the credentials will be saved unencrypted on disk\n"
-        b"To approve credentials for this operation, please navigate to the following URL and approve the request:\n"
-        b"https://example-issuer.org/device?user_code=ABC-123-XYZ\n" + fake_jwt.encode() + b"\n"
+    # Mock pexpect child with OIDC URL display followed by token output
+    mock_child = MockPexpectChild(
+        [
+            (1, "WARNING: empty password provided\n", "https://example-issuer.org/device?user_code=ABC-123-XYZ"),  # OIDC URL
+            (2, f"\n{fake_jwt}\n", ""),  # EOF with token
+        ]
     )
 
-    mock_read.side_effect = [full_output, b""]
-    mock_select.side_effect = [([100], [], []), ([], [], []), ([], [], [])]
+    mock_pexpect.spawn = MagicMock(return_value=mock_child)
 
-    iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-    iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-    token = next(iterator)
+                token = next(iterator)
 
     assert token.startswith("eyJ")
     assert len(token.split(".")) == 3
     assert token == fake_jwt
 
-    mock_popen.assert_called_once()
-    call_args = mock_popen.call_args[0][0]
-    assert "pelican" in call_args
-    assert "token" in call_args
-    assert "fetch" in call_args
-    assert "pelican://example.com/path" in call_args
-    assert "-r" in call_args
+    # Verify spawn was called with expected command
+    mock_pexpect.spawn.assert_called_once()
+    call_args = mock_pexpect.spawn.call_args
+    cmd_str = call_args[0][0]
+    assert "pelican" in cmd_str
+    assert "token" in cmd_str
+    assert "fetch" in cmd_str
+    assert "pelican://example.com/path" in cmd_str
+    assert "-r" in cmd_str
 
 
-@patch("shutil.which", return_value="/usr/bin/pelican")
-@patch("pty.openpty")
-@patch("subprocess.Popen")
-@patch("os.read")
-@patch("os.write")
-@patch("os.close")
-@patch("select.select")
-def test_oidc_device_flow_with_warning_prefix(mock_select, mock_close, mock_write, mock_read, mock_popen, mock_openpty, mock_which):
+def test_oidc_device_flow_with_warning_prefix(mock_pexpect):
     """Test token extraction when output has warning prefix"""
     from pelicanfs.token_generator import TokenOperation
 
     fake_jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.abc123def456"
 
-    # Mock PTY
-    mock_openpty.return_value = (100, 101)
+    # Mock pexpect child with warning message followed by token
+    mock_child = MockPexpectChild(
+        [
+            (2, f"Token was acquired from issuer but it does not appear valid for transfer; trying anyway\n{fake_jwt}\n", ""),  # EOF with warning + token
+        ]
+    )
 
-    mock_process = mock_popen.return_value
-    mock_process.returncode = 0
-    mock_process.poll.side_effect = [None, 0]
+    mock_pexpect.spawn = MagicMock(return_value=mock_child)
 
-    full_output = b"Token was acquired from issuer but it does not appear valid for transfer; trying anyway\n" + fake_jwt.encode() + b"\n"
-    mock_read.side_effect = [full_output, b""]
-    mock_select.side_effect = [([100], [], []), ([], [], []), ([], [], [])]
+    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-    iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-    iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
-
-    token = next(iterator)
+                token = next(iterator)
 
     assert token.startswith("eyJ")
     assert "trying anyway" not in token  # Warning prefix should not be in token
     assert token == fake_jwt
 
 
-@patch("shutil.which", return_value="/usr/bin/pelican")
-@patch("pty.openpty")
-@patch("subprocess.Popen")
-@patch("os.read")
-@patch("os.write")
-@patch("os.close")
-@patch("select.select")
-def test_oidc_device_flow_write_operation(mock_select, mock_close, mock_write, mock_read, mock_popen, mock_openpty, mock_which):
+def test_oidc_device_flow_write_operation(mock_pexpect):
     """Test that write operation uses -w flag"""
     from pelicanfs.token_generator import TokenOperation
 
     fake_jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ3cml0ZSJ9.xyz789abc"
 
-    # Mock PTY
-    mock_openpty.return_value = (100, 101)
+    # Mock pexpect child with token output
+    mock_child = MockPexpectChild(
+        [
+            (2, f"{fake_jwt}\n", ""),  # EOF with token
+        ]
+    )
 
-    mock_process = mock_popen.return_value
-    mock_process.returncode = 0
-    mock_process.poll.side_effect = [None, 0]
+    mock_pexpect.spawn = MagicMock(return_value=mock_child)
 
-    mock_read.side_effect = [fake_jwt.encode() + b"\n", b""]
-    mock_select.side_effect = [([100], [], []), ([], [], [])]
+    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenWrite, pelican_url="pelican://example.com/write/path")
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-    iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenWrite, pelican_url="pelican://example.com/write/path")
-    iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
-
-    token = next(iterator)
+                token = next(iterator)
 
     # Verify -w flag was used for write operation
-    call_args = mock_popen.call_args[0][0]
-    assert "pelican" in call_args
-    assert "token" in call_args
-    assert "fetch" in call_args
-    assert "pelican://example.com/write/path" in call_args
-    assert "-w" in call_args
+    mock_pexpect.spawn.assert_called_once()
+    cmd_str = mock_pexpect.spawn.call_args[0][0]
+    assert "pelican" in cmd_str
+    assert "token" in cmd_str
+    assert "fetch" in cmd_str
+    assert "pelican://example.com/write/path" in cmd_str
+    assert "-w" in cmd_str
     assert token == fake_jwt
 
 
-@patch("shutil.which", return_value="/usr/bin/pelican")
-@patch("pty.openpty")
-@patch("subprocess.Popen")
-@patch("os.read")
-@patch("os.write")
-@patch("os.close")
-@patch("select.select")
-def test_oidc_device_flow_binary_fails(mock_select, mock_close, mock_write, mock_read, mock_popen, mock_openpty, mock_which):
+def test_oidc_device_flow_binary_fails(mock_pexpect):
     """Test that StopIteration is raised when pelican binary exits with error"""
     from pelicanfs.token_generator import TokenOperation
 
-    # Mock PTY
-    mock_openpty.return_value = (100, 101)
+    # Mock pexpect child with error exit status
+    mock_child = MockPexpectChild(
+        [
+            (2, "Error: failed to authenticate\n", ""),  # EOF with error
+        ],
+        exit_status=1,
+    )
 
-    mock_process = mock_popen.return_value
-    mock_process.returncode = 1
-    mock_process.poll.side_effect = [None, 1]
+    mock_pexpect.spawn = MagicMock(return_value=mock_child)
 
-    mock_read.side_effect = [b"Error: failed to authenticate\n", b""]
-    mock_select.side_effect = [([100], [], []), ([], [], [])]
+    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
+        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
+            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
+                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+                iterator._pelican_binary_exists = MagicMock(return_value=True)
+                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-    iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-    iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
-
-    with pytest.raises(StopIteration):
-        next(iterator)
+                with pytest.raises(StopIteration):
+                    next(iterator)
 
 
 @patch("shutil.which", return_value="/usr/bin/pelican")

--- a/test/test_tci.py
+++ b/test/test_tci.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import json
-import sys
+from contextlib import contextmanager
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -76,9 +76,20 @@ class MockTIMEOUT(Exception):
     pass
 
 
+@contextmanager
+def patch_expect_module(mock_module):
+    """Patch the bound pexpect/wexpect module and exception constants."""
+    with (
+        patch("pelicanfs.token_content_iterator._expect_module", mock_module),
+        patch("pelicanfs.token_content_iterator._EOF", MockEOF),
+        patch("pelicanfs.token_content_iterator._TIMEOUT", MockTIMEOUT),
+    ):
+        yield
+
+
 @pytest.fixture
-def mock_pexpect():
-    """Create a mock pexpect module."""
+def mock_expect_module():
+    """Create a mock pexpect/wexpect module."""
     mock_module = MagicMock()
     mock_module.EOF = MockEOF
     mock_module.TIMEOUT = MockTIMEOUT
@@ -260,7 +271,7 @@ def test_oidc_device_flow_binary_not_found(mock_which, caplog):
     assert any("pelican' binary is installed" in record.message for record in caplog.records)
 
 
-def test_oidc_device_flow_successful_token_acquisition(mock_pexpect):
+def test_oidc_device_flow_successful_token_acquisition(mock_expect_module):
     """Test successful token acquisition via OIDC device flow"""
     from pelicanfs.token_generator import TokenOperation
 
@@ -274,24 +285,22 @@ def test_oidc_device_flow_successful_token_acquisition(mock_pexpect):
         ]
     )
 
-    mock_pexpect.spawn = MagicMock(return_value=mock_child)
+    mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-                iterator._pelican_binary_exists = MagicMock(return_value=True)
-                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+    with patch_expect_module(mock_expect_module):
+        iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+        iterator._pelican_binary_exists = MagicMock(return_value=True)
+        iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-                token = next(iterator)
+        token = next(iterator)
 
     assert token.startswith("eyJ")
     assert len(token.split(".")) == 3
     assert token == fake_jwt
 
     # Verify spawn was called with expected command
-    mock_pexpect.spawn.assert_called_once()
-    call_args = mock_pexpect.spawn.call_args
+    mock_expect_module.spawn.assert_called_once()
+    call_args = mock_expect_module.spawn.call_args
     cmd_str = call_args[0][0]
     assert "pelican" in cmd_str
     assert "token" in cmd_str
@@ -300,7 +309,7 @@ def test_oidc_device_flow_successful_token_acquisition(mock_pexpect):
     assert "-r" in cmd_str
 
 
-def test_oidc_device_flow_with_warning_prefix(mock_pexpect):
+def test_oidc_device_flow_with_warning_prefix(mock_expect_module):
     """Test token extraction when output has warning prefix"""
     from pelicanfs.token_generator import TokenOperation
 
@@ -313,23 +322,21 @@ def test_oidc_device_flow_with_warning_prefix(mock_pexpect):
         ]
     )
 
-    mock_pexpect.spawn = MagicMock(return_value=mock_child)
+    mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-                iterator._pelican_binary_exists = MagicMock(return_value=True)
-                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+    with patch_expect_module(mock_expect_module):
+        iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+        iterator._pelican_binary_exists = MagicMock(return_value=True)
+        iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-                token = next(iterator)
+        token = next(iterator)
 
     assert token.startswith("eyJ")
     assert "trying anyway" not in token  # Warning prefix should not be in token
     assert token == fake_jwt
 
 
-def test_oidc_device_flow_write_operation(mock_pexpect):
+def test_oidc_device_flow_write_operation(mock_expect_module):
     """Test that write operation uses -w flag"""
     from pelicanfs.token_generator import TokenOperation
 
@@ -342,20 +349,18 @@ def test_oidc_device_flow_write_operation(mock_pexpect):
         ]
     )
 
-    mock_pexpect.spawn = MagicMock(return_value=mock_child)
+    mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenWrite, pelican_url="pelican://example.com/write/path")
-                iterator._pelican_binary_exists = MagicMock(return_value=True)
-                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+    with patch_expect_module(mock_expect_module):
+        iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenWrite, pelican_url="pelican://example.com/write/path")
+        iterator._pelican_binary_exists = MagicMock(return_value=True)
+        iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-                token = next(iterator)
+        token = next(iterator)
 
     # Verify -w flag was used for write operation
-    mock_pexpect.spawn.assert_called_once()
-    cmd_str = mock_pexpect.spawn.call_args[0][0]
+    mock_expect_module.spawn.assert_called_once()
+    cmd_str = mock_expect_module.spawn.call_args[0][0]
     assert "pelican" in cmd_str
     assert "token" in cmd_str
     assert "fetch" in cmd_str
@@ -364,7 +369,7 @@ def test_oidc_device_flow_write_operation(mock_pexpect):
     assert token == fake_jwt
 
 
-def test_oidc_device_flow_binary_fails(mock_pexpect):
+def test_oidc_device_flow_binary_fails(mock_expect_module):
     """Test that StopIteration is raised when pelican binary exits with error"""
     from pelicanfs.token_generator import TokenOperation
 
@@ -376,17 +381,15 @@ def test_oidc_device_flow_binary_fails(mock_pexpect):
         exit_status=1,
     )
 
-    mock_pexpect.spawn = MagicMock(return_value=mock_child)
+    mock_expect_module.spawn = MagicMock(return_value=mock_child)
 
-    with patch.dict(sys.modules, {"pexpect": mock_pexpect}):
-        with patch("pelicanfs.token_content_iterator._PEXPECT_AVAILABLE", True):
-            with patch("pelicanfs.token_content_iterator.pexpect", mock_pexpect):
-                iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
-                iterator._pelican_binary_exists = MagicMock(return_value=True)
-                iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
+    with patch_expect_module(mock_expect_module):
+        iterator = TokenContentIterator(location=None, name="token_name", operation=TokenOperation.TokenRead, pelican_url="pelican://example.com/path")
+        iterator._pelican_binary_exists = MagicMock(return_value=True)
+        iterator.method_index = iterator.get_method_index(TokenDiscoveryMethod.OIDC_DEVICE_FLOW)
 
-                with pytest.raises(StopIteration):
-                    next(iterator)
+        with pytest.raises(StopIteration):
+            next(iterator)
 
 
 @patch("shutil.which", return_value="/usr/bin/pelican")


### PR DESCRIPTION
Major improvements to the Jupyter interface when using OAuth work.

Replaced the previous PTY/subprocess approach with pexpect (Unix) / wexpect (Windows) for interacting with the pelican binary during OIDC device flow and now has a much cleaner Jupyter interaction and device flow (no longer need to wrap pelicanfs Jupyter calls)